### PR TITLE
Group category names should not have to globally unique

### DIFF
--- a/src/admin/CompetitionSettings.php
+++ b/src/admin/CompetitionSettings.php
@@ -154,7 +154,9 @@ class CompetitionSettings {
 
 				$new_template_id = $message_template_dao->create( $new_template );
 			} catch ( ValidationException $e ) {
+				AdminUtils::printException( $e );
 			} catch ( Exception $e ) {
+				AdminUtils::printException( $e );
 			}
 		}
 
@@ -167,7 +169,9 @@ class CompetitionSettings {
 
 					$affected_rows = $message_template_dao->update( $message_template_map[ $id ] );
 				} catch ( ValidationException $e ) {
+					AdminUtils::printException( $e );
 				} catch ( Exception $e ) {
+					AdminUtils::printException( $e );
 				}
 			}
 		}
@@ -175,13 +179,15 @@ class CompetitionSettings {
 		foreach ( $deleted_ids as $id ) {
 			if ( isset( $message_template_map[ $id ] ) ) {
 				$delete_successful = $message_template_dao->delete( $id );
+				if ( ! $delete_successful ) {
+					AdminUtils::printError( 'Could not delete message template' );
+				}
 			}
 		}
 	}
 
 	public function competition_settings_save_group_categories( Competition $competition ) {
-		global $wpdb;
-		$category_dao = new GroupCategoryDao( $wpdb );
+		$category_dao = new GroupCategoryDao();
 
 		$categories = $category_dao->get_all_in_competition( $competition->id );
 
@@ -208,7 +214,9 @@ class CompetitionSettings {
 
 				$new_template_id = $category_dao->create( $new_template );
 			} catch ( ValidationException $e ) {
+				AdminUtils::printException( $e );
 			} catch ( Exception $e ) {
+				AdminUtils::printException( $e );
 			}
 		}
 
@@ -220,7 +228,9 @@ class CompetitionSettings {
 
 					$affected_rows = $category_dao->update( $category_map[ $id ] );
 				} catch ( ValidationException $e ) {
+					AdminUtils::printException( $e );
 				} catch ( Exception $e ) {
+					AdminUtils::printException( $e );
 				}
 			}
 		}
@@ -228,6 +238,9 @@ class CompetitionSettings {
 		foreach ( $deleted_ids as $id ) {
 			if ( isset( $category_map[ $id ] ) ) {
 				$delete_successful = $category_dao->delete( $id );
+				if ( ! $delete_successful ) {
+					AdminUtils::printError( 'Could not delete category' );
+				}
 			}
 		}
 	}

--- a/src/data/model/GroupCategory.php
+++ b/src/data/model/GroupCategory.php
@@ -10,7 +10,13 @@ class GroupCategory
     public $is_crew;
     public $name;
 
-    public function validate()
-    {
-    }
+	public function validate()
+	{
+		if (strlen(trim($this->name)) < 1) {
+			throw new ValidationException('name', 'Namnet måste fyllas i.');
+		}
+		if (strlen($this->name) > 20) {
+			throw new ValidationException('name', 'Namnet får inte vara längre än 20 bokstäver.');
+		}
+	}
 }

--- a/src/data/store/GroupCategoryDao.php
+++ b/src/data/store/GroupCategoryDao.php
@@ -18,7 +18,7 @@ class GroupCategoryDao extends AbstractDao
     {
         $category->validate();
 
-        if ($this->exists($category->name, $category->id)) {
+        if ($this->exists($category)) {
             throw new ValidationException('name', 'Det finns redan en kategori med detta namn.');
         }
 
@@ -42,7 +42,7 @@ class GroupCategoryDao extends AbstractDao
     {
         $category->validate();
 
-        if ($this->exists($category->name, $category->id)) {
+        if ($this->exists($category)) {
             throw new ValidationException('name', 'Det finns redan en kategori med detta namn.');
         }
 
@@ -56,13 +56,14 @@ class GroupCategoryDao extends AbstractDao
             ));
     }
 
-    function exists($name, $exclude_group_id)
+    function exists(GroupCategory $category)
     {
         $db_results = $this->wpdb->get_results(
             $this->wpdb->prepare(
-                'SELECT id FROM ' . $this->table . ' WHERE name = %s AND id != %d',
-                $name,
-                $exclude_group_id),
+                'SELECT id FROM ' . $this->table . ' WHERE name = %s AND id != %d AND competition_id = %d',
+	            $category->name,
+	            $category->id,
+	            $category->competition_id),
             OBJECT);
         return $db_results !== false && count($db_results) > 0;
     }


### PR DESCRIPTION
- Begränsa så att en gruppkategoris namn bara behöver vara unikt inom en och samma tävling.
- Bättre felhantering.