### PR TITLE
Group registration rules

### DIFF
--- a/src/admin/Group.php
+++ b/src/admin/Group.php
@@ -84,7 +84,7 @@ class Group {
 		$person_dao = new PersonDao();
 		$people = $person_dao->get_all_in_group( $group->id );
 
-		$registration_evaluator  = new RegistrationEvaluator( $this->competition->id );
+		$registration_evaluator  = new RegistrationEvaluator();
 		$registration_evaluation = $registration_evaluator->evaluate( $group );
 
 		include('views/group.php');

--- a/src/admin/Group.php
+++ b/src/admin/Group.php
@@ -6,7 +6,7 @@ use tuja\data\store\CompetitionDao;
 use tuja\data\store\FormDao;
 use tuja\data\store\MessageDao;
 use tuja\data\store\PersonDao;
-use tuja\view\FieldImages;
+use tuja\util\rules\RegistrationEvaluator;
 use tuja\data\store\QuestionDao;
 use tuja\data\store\PointsDao;
 use tuja\util\score\ScoreCalculator;
@@ -86,6 +86,9 @@ class Group {
 
 		$person_dao = new PersonDao();
 		$people = $person_dao->get_all_in_group( $group->id );
+
+		$registration_evaluator  = new RegistrationEvaluator( $this->competition->id );
+		$registration_evaluation = $registration_evaluator->evaluate( $group );
 
 		include('views/group.php');
 	}

--- a/src/admin/MessagesSend.php
+++ b/src/admin/MessagesSend.php
@@ -28,17 +28,70 @@ class MessagesSend {
 	}
 
 
-	public function handle_post() {
-		if(!isset($_POST['tuja_points_action'])) return;
-		
-		if ( $_POST['tuja_points_action'] === 'send' ) {
-			// TODO?
+	public function handle_post( $group_selectors, $people_selectors, $delivery_methods, $groups ) {
+		if ( ! isset( $_POST['tuja_messages_action'] ) ) {
+			return [];
+		}
+
+		$is_preview = $_POST['tuja_messages_action'] === 'preview';
+		$is_send    = $_POST['tuja_messages_action'] === 'send';
+
+		if ( $is_preview || $is_send ) {
+			$group_selector  = $group_selectors[ intval( $_POST['tuja_messages_group_selector'] ) ];
+			$people_selector = $people_selectors[ $_POST['tuja_messages_people_selector'] ];
+			$delivery_method = $delivery_methods[ $_POST['tuja_messages_delivery_method'] ];
+			if ( isset( $group_selector ) && isset( $people_selector ) && isset( $delivery_method ) ) {
+				$selected_groups = array_filter( $groups, $group_selector['selector'] );
+
+				$person_dao = new PersonDao();
+				$people     = [];
+				foreach ( $selected_groups as $selected_group ) {
+					$group_members = array_filter( $person_dao->get_all_in_group( $selected_group->id ), $people_selector['selector'] );
+					$people        = array_merge( $people, $group_members );
+				}
+
+				$body_template    = Template::string( $_POST['tuja_messages_body'] );
+				$subject_template = Template::string( $_POST['tuja_messages_subject'] );
+
+				$variables = array_merge( $body_template->get_variables(), $subject_template->get_variables() );
+
+				return [
+					'body_template'    => $body_template,
+					'subject_template' => $subject_template,
+					'variables'        => $variables,
+					'recipients'       => array_map( function ( $person ) use ( $delivery_method, $variables, $groups, $subject_template, $body_template, $is_send ) {
+						$group               = reset( array_filter( $groups, function ( $grp ) use ( $person ) {
+							return $grp->id == $person->group_id;
+						} ) );
+						$template_parameters = $this->get_parameters( $person, $group );
+						$message_generator   = $delivery_method['message_generator'];
+						$outgoing_message    = $message_generator( $person, $subject_template, $body_template, $template_parameters );
+						$is_valid            = 'OK';
+						try {
+							if ( $is_send ) {
+								$outgoing_message->send();
+								$is_valid = 'Meddelande har skickats';
+							} else {
+								$outgoing_message->validate();
+							}
+						} catch ( Exception $e ) {
+							$is_valid = $e->getMessage();
+						}
+
+						return [
+							'template_parameters' => $template_parameters,
+							'is_valid'            => $is_valid,
+							'person_name'         => $person->name,
+							'is_plain_text_body'  => $delivery_method['is_plain_text_body']
+						];
+					}, $people )
+
+				];
+			}
 		}
 	}
 
 	public function output() {
-		$this->handle_post();
-
 		// TODO: Make helper function for generating URLs
 		$competition     = $this->competition;
 		$competition_url = add_query_arg( array(
@@ -55,6 +108,7 @@ class MessagesSend {
 		} ) );
 
 		$group_dao       = new GroupDao();
+		$groups          = $group_dao->get_all_in_competition( $competition->id );
 		$group_selectors = array_merge(
 			array(
 				array(
@@ -65,6 +119,12 @@ class MessagesSend {
 				),
 				array(
 					'label'    => 'Alla tävlande grupper',
+					'selector' => function ( $group ) use ( $crew_category_ids ) {
+						return ! in_array( $group->category_id, $crew_category_ids );
+					}
+				),
+				array(
+					'label'    => 'Alla tävlande grupper med ofullständiga anmälningar',
 					'selector' => function ( $group ) use ( $crew_category_ids ) {
 						return ! in_array( $group->category_id, $crew_category_ids );
 					}
@@ -95,7 +155,7 @@ class MessagesSend {
 						}
 					);
 				},
-				( $group_dao )->get_all_in_competition( $competition->id ) ) );
+				$groups ) );
 
 		$people_selectors = array(
 			'all'              => array(
@@ -136,6 +196,10 @@ class MessagesSend {
 			)
 		);
 
+		$groups = $group_dao->get_all_in_competition( $this->competition->id );
+
+		$action_result = $this->handle_post( $group_selectors, $people_selectors, $delivery_methods, $groups );
+
 		$message_template_dao = new MessageTemplateDao();
 		$templates            = $message_template_dao->get_all_in_competition( $competition->id );
 
@@ -148,72 +212,6 @@ class MessagesSend {
 		$is_send    = $_POST['tuja_messages_action'] === 'send';
 
 		include( 'views/messages-send.php' );
-
-		$is_preview = $_POST['tuja_messages_action'] === 'preview';
-		$is_send    = $_POST['tuja_messages_action'] === 'send';
-
-
-		if ( $is_preview || $is_send ) {
-
-			ob_start();
-
-			$group_selector  = $group_selectors[ intval( $_POST['tuja_messages_group_selector'] ) ];
-			$people_selector = $people_selectors[ $_POST['tuja_messages_people_selector'] ];
-			$delivery_method = $delivery_methods[ $_POST['tuja_messages_delivery_method'] ];
-			if ( isset( $group_selector ) && isset( $people_selector ) && isset( $delivery_method ) ) {
-				$groups          = $group_dao->get_all_in_competition( $this->competition->id );
-				$selected_groups = array_filter( $groups, $group_selector['selector'] );
-
-				$person_dao = new PersonDao();
-				$people     = [];
-				foreach ( $selected_groups as $selected_group ) {
-					$group_members = array_filter( $person_dao->get_all_in_group( $selected_group->id ), $people_selector['selector'] );
-					$people        = array_merge( $people, $group_members );
-				}
-
-				$body_template    = Template::string( $_POST['tuja_messages_body'] );
-				$subject_template = Template::string( $_POST['tuja_messages_subject'] );
-
-				$variables = array_merge( $body_template->get_variables(), $subject_template->get_variables() );
-				printf( '<table>' );
-				printf( '<thead><tr><td colspan="2"><strong>Mottagare</strong></td>%s<td><strong>Förhandsgranskning</strong></td></tr></thead>', join( array_map( function ( $variable ) {
-					return sprintf( '<td><strong>%s</strong></td>', $variable );
-				}, $variables ) ) );
-				printf( '<tbody>%s</tbody>', join( array_map( function ( $person ) use ( $delivery_method, $variables, $groups, $subject_template, $body_template, $is_send ) {
-					$group               = reset( array_filter( $groups, function ( $grp ) use ( $person ) {
-						return $grp->id == $person->group_id;
-					} ) );
-					$template_parameters = $this->get_parameters( $person, $group );
-					$message_generator   = $delivery_method['message_generator'];
-					$outgoing_message    = $message_generator( $person, $subject_template, $body_template, $template_parameters );
-					$is_valid            = 'OK';
-					try {
-						if ( $is_send ) {
-							$outgoing_message->send();
-							$is_valid = 'Meddelande har skickats';
-						} else {
-							$outgoing_message->validate();
-						}
-					} catch ( Exception $e ) {
-						$is_valid = $e->getMessage();
-					}
-
-					return sprintf( '<tr><td valign="top">%s</td><td valign="top">%s</td>%s<td valign="top">%s</td></tr>',
-						$person->name,
-						$is_valid,
-						join( array_map( function ( $variable ) use ( $template_parameters ) {
-							return sprintf( '<td valign="top">%s</td>', $template_parameters[ $variable ] );
-						}, $variables ) ),
-						sprintf( '<div class="tuja-message-preview">%s</div><div class="tuja-message-preview %s">%s</div>',
-							strip_tags( $subject_template->render( $template_parameters ) ),
-							$delivery_method['is_plain_text_body'] ? 'tuja-message-preview-plaintext' : 'tuja-message-preview-html',
-							$body_template->render( $template_parameters, ! $delivery_method['is_plain_text_body'] ) ) );
-				}, $people ) ) );
-				printf( '</table>' );
-			}
-
-			echo ob_get_clean();
-		}
 	}
 
 

--- a/src/admin/views/group.php
+++ b/src/admin/views/group.php
@@ -2,6 +2,7 @@
 namespace tuja\admin;
 
 use DateTime;
+use tuja\util\rules\RuleResult;
 use tuja\view\FieldImages;
 
 ?>
@@ -10,6 +11,25 @@ use tuja\view\FieldImages;
     <h1>Tävling <?= sprintf('<a href="%s">%s</a>', $competition_url, $this->competition->name) ?></h1>
     <h2>Grupp <?= htmlspecialchars($group->name) ?> (id: <code><?= htmlspecialchars($group->random_id) ?></code>)</h2>
 
+    <h3>Status för anmälan</h3>
+
+	<?php
+
+	$css_class_mapping = [
+		RuleResult::OK      => 'notice-success',
+		RuleResult::WARNING => 'notice-warning',
+		RuleResult::BLOCKER => 'notice-error'
+	];
+
+	foreach ( $registration_evaluation as $result ) {
+		printf( '<div class="notice %s" style="margin-left: 2px"><p><strong>%s: </strong>%s</p></div>',
+			$css_class_mapping[ $result->status ],
+			$result->rule_name,
+			$result->details );
+	}
+	?>
+
+    <h3>Svar och poäng</h3>
     <p><strong>Totalt <?= array_sum($calculated_scores_final) ?> poäng.</strong></p>
 
     <table class="tuja-admin-review">

--- a/src/admin/views/messages-send.php
+++ b/src/admin/views/messages-send.php
@@ -131,25 +131,30 @@ if ( ! empty( $action_result ) ) {
 
 	printf( '<table>' .
 	        '  <thead>' .
-	        '    <tr>' .
-	        '      <td colspan="2"><strong>Mottagare</strong></td>' .
-	        '      %s' .
-	        '      <td><strong>Förhandsgranskning</strong></td>' .
-	        '    </tr>' .
+	        '  <tr>' .
+	        '    <td colspan="2" rowspan="2" valign="top"><strong>Mottagare</strong>' .
+	        '    <td colspan="%d"><strong>Variabler</strong></td>' .
+	        '    <td colspan="2" rowspan="2" valign="top"><strong>Förhandsgranskning</strong></td>' .
+	        '  </tr>' .
+	        '  <tr>' .
+	        '    %s' .
+	        '  </tr>' .
 	        '  </thead>' .
 	        '  <tbody>' .
 	        '    %s' .
 	        '  </tbody>' .
 	        '</table>',
+		count( $variables ),
 		$variables_headers_html,
 		join( array_map( function ( $result ) use ( $variables, $subject_template, $body_template ) {
-			$person              = $result['person_name'];
+			$person_name         = $result['person_name'];
 			$template_parameters = $result['template_parameters'];
-			$is_valid            = $result['is_valid'];
+			$message             = $result['message'];
+			$message_css_class   = $result['message_css_class'];
 			$is_plain_text_body  = $result['is_plain_text_body'];
 
 			$variables_values_html = join( array_map( function ( $variable ) use ( $template_parameters ) {
-				return sprintf( '<td valign="top">%s</td>', $template_parameters[ $variable ] );
+				return sprintf( '<td valign="top"><code>%s</code></td>', $template_parameters[ $variable ] );
 			}, $variables ) );
 
 			$preview_html = sprintf( '<div class="tuja-message-preview">%s</div><div class="tuja-message-preview %s">%s</div>',
@@ -157,9 +162,16 @@ if ( ! empty( $action_result ) ) {
 				$is_plain_text_body ? 'tuja-message-preview-plaintext' : 'tuja-message-preview-html',
 				$body_template->render( $template_parameters, ! $is_plain_text_body ) );
 
-			return sprintf( '<tr><td valign="top">%s</td><td valign="top">%s</td>%s<td valign="top">%s</td></tr>',
-				$person,
-				$is_valid,
+			return sprintf(
+				'<tr>' .
+				'  <td valign="top">%s</td>' .
+				'  <td valign="top"><span class="tuja-admin-review-autoscore %s">%s</span></td>' .
+				'  %s' .
+				'  <td valign="top">%s</td>' .
+				'</tr>',
+				$person_name,
+				$message_css_class,
+				$message,
 				$variables_values_html,
 				$preview_html );
 		}, $action_result['recipients'] ) ) );

--- a/src/admin/views/messages-send.php
+++ b/src/admin/views/messages-send.php
@@ -1,8 +1,9 @@
-<?php 
-	namespace tuja\admin; 
-	
-	use tuja\data\model\Group;
-	use tuja\data\model\Person;
+<?php
+
+namespace tuja\admin;
+
+use tuja\data\model\Group;
+use tuja\data\model\Person;
 ?>
 
 <h1>Tunnelbanejakten</h1>
@@ -116,3 +117,50 @@
 		</div>
 	<?php } ?>
 </form>
+	<?php
+if ( ! empty( $action_result ) ) {
+	$variables        = $action_result['variables'];
+	$body_template    = $action_result['body_template'];
+	$subject_template = $action_result['subject_template'];
+
+	$variables_headers_html = join( array_map( function ( $variable ) {
+		return sprintf( '<td><strong>%s</strong></td>', $variable );
+	}, $variables ) );
+
+	printf( '<table>' .
+	        '  <thead>' .
+	        '    <tr>' .
+	        '      <td colspan="2"><strong>Mottagare</strong></td>' .
+	        '      %s' .
+	        '      <td><strong>Förhandsgranskning</strong></td>' .
+	        '    </tr>' .
+	        '  </thead>' .
+	        '  <tbody>' .
+	        '    %s' .
+	        '  </tbody>' .
+	        '</table>',
+		$variables_headers_html,
+		join( array_map( function ( $result ) use ( $variables, $subject_template, $body_template ) {
+			$person              = $result['person_name'];
+			$template_parameters = $result['template_parameters'];
+			$is_valid            = $result['is_valid'];
+			$is_plain_text_body  = $result['is_plain_text_body'];
+
+			$variables_values_html = join( array_map( function ( $variable ) use ( $template_parameters ) {
+				return sprintf( '<td valign="top">%s</td>', $template_parameters[ $variable ] );
+			}, $variables ) );
+
+			$preview_html = sprintf( '<div class="tuja-message-preview">%s</div><div class="tuja-message-preview %s">%s</div>',
+				strip_tags( $subject_template->render( $template_parameters ) ),
+				$is_plain_text_body ? 'tuja-message-preview-plaintext' : 'tuja-message-preview-html',
+				$body_template->render( $template_parameters, ! $is_plain_text_body ) );
+
+			return sprintf( '<tr><td valign="top">%s</td><td valign="top">%s</td>%s<td valign="top">%s</td></tr>',
+				$person,
+				$is_valid,
+				$variables_values_html,
+				$preview_html );
+		}, $action_result['recipients'] ) ) );
+}
+
+?>

--- a/src/assets/css/admin.css
+++ b/src/assets/css/admin.css
@@ -88,6 +88,14 @@ body.wp-admin th {
 .tuja-message-preview.tuja-message-preview-plaintext {
     white-space: pre;
 }
+
+.tuja-message-preview.tuja-message-preview-html ul {
+    list-style: disc;
+}
+
+.tuja-message-preview.tuja-message-preview-html li {
+    margin: 0 0 6px 24px;
+}
 .tuja-tab {
     border-bottom: 1px solid #ccc;
     border-right: 1px solid #ccc;

--- a/src/data/model/Group.php
+++ b/src/data/model/Group.php
@@ -3,13 +3,17 @@
 namespace tuja\data\model;
 
 
+use tuja\util\GroupCategoryCalculator;
+
 class Group
 {
-    public $id;
-    public $random_id;
-    public $competition_id;
-    public $name;
-    public $category_id;
+	private static $group_calculators = [];
+
+	public $id;
+	public $random_id;
+	public $competition_id;
+	public $name;
+	public $category_id;
 	public $age_competing_avg;
 	public $age_competing_stddev;
 	public $age_competing_min;
@@ -18,13 +22,25 @@ class Group
 	public $count_follower;
 	public $count_team_contact;
 
-    public function validate()
-    {
-        if (strlen(trim($this->name)) < 1) {
-            throw new ValidationException('name', 'Namnet måste fyllas i.');
-        }
-        if (strlen($this->name) > 100) {
-            throw new ValidationException('name', 'Namnet får inte vara längre än 100 bokstäver.');
-        }
-    }
+	public function validate() {
+		if ( strlen(trim($this->name)) < 1) {
+			throw new ValidationException('name', 'Namnet måste fyllas i.');
+		}
+		if ( strlen($this->name) > 100) {
+			throw new ValidationException('name', 'Namnet får inte vara längre än 100 bokstäver.');
+		}
+	}
+
+	public function get_derived_group_category() {
+		return self::get_group_calculator( $this->competition_id )->get_category( $this );
+	}
+
+	private static function get_group_calculator( $competition_id ): GroupCategoryCalculator {
+		if ( ! isset( self::$group_calculators[ $competition_id ] ) ) {
+			self::$group_calculators[ $competition_id ] = new GroupCategoryCalculator( $competition_id );
+		}
+
+		return self::$group_calculators[ $competition_id ];
+	}
+
 }

--- a/src/data/model/Person.php
+++ b/src/data/model/Person.php
@@ -43,6 +43,7 @@ class Person
     public $is_competing;
     public $is_group_contact;
     public $pno;
+	public $age;
 
 	public static function is_valid_email_address( $email ) {
 		return preg_match( '/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i', $email ) === 1;

--- a/src/data/model/Person.php
+++ b/src/data/model/Person.php
@@ -29,7 +29,7 @@ class Person
 	- nej
 	*/
 	const PNO_PATTERN = '^(19|20)?[0-9]{2}-?(0[1-9]|[1-2][0-9])-?[0-3][0-9](-*[0-9]{4})?$';
-	CONST PHONE_PATTERN = '^\+?[0-9 -]{6,}$';
+	const PHONE_PATTERN = '^\+?[0-9 -]{6,}$';
 
     public $id;
     public $random_id;
@@ -44,7 +44,15 @@ class Person
     public $is_group_contact;
     public $pno;
 
-    public function validate()
+	public static function is_valid_email_address( $email ) {
+		return preg_match( '/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i', $email ) === 1;
+	}
+
+	public static function is_valid_phone_number( $phone ) {
+		return preg_match( '/' . self::PHONE_PATTERN . '/', $phone ) === 1;
+	}
+
+	public function validate()
     {
         if (empty(trim($this->name))) {
             throw new ValidationException('name', 'Namnet måste fyllas i.');
@@ -52,16 +60,16 @@ class Person
         if (strlen($this->name) > 100) {
             throw new ValidationException('name', 'Namnet får inte vara längre än 100 bokstäver.');
         }
-        if (strlen($this->email) > 100) {
+	    if ( strlen( $this->email ) > 100 ) {
             throw new ValidationException('email', 'E-postadress får bara vara 100 tecken lång.');
         }
-        if (!empty(trim($this->email)) && preg_match('/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i', $this->email) !== 1) {
+	    if ( ! empty( trim( $this->email ) ) && ! self::is_valid_email_address( $this->email ) ) {
             throw new ValidationException('email', 'E-postadressen ser konstig ut.');
         }
-        if (strlen($this->phone) > 100) {
+	    if ( strlen( $this->phone ) > 100 ) {
             throw new ValidationException('phone', 'Telefonnumret får bara vara 100 tecken långt.');
         }
-	    if ( !empty(trim($this->phone)) && preg_match( '/' . self::PHONE_PATTERN . '/', $this->phone) !== 1) {
+	    if ( ! empty( trim( $this->phone ) ) && ! self::is_valid_phone_number( $this->phone ) ) {
             throw new ValidationException('phone', 'Telefonnummer ser konstigt ut.');
         }
         if (strlen($this->food) > 65000) {

--- a/src/data/store/AbstractDao.php
+++ b/src/data/store/AbstractDao.php
@@ -52,25 +52,6 @@ class AbstractDao {
 		return $gc;
 	}
 
-	protected static function to_person( $result ): Person {
-		$p                   = new Person();
-		$p->id               = $result->id;
-		$p->random_id        = $result->random_id;
-		$p->name             = $result->name;
-		$p->group_id         = $result->team_id;
-		// TODO: Should normalizing the phone number be something we do when we read it from the database? Why not when stored?
-		$p->phone            = Phone::fix_phone_number( $result->phone );
-		$p->phone_verified   = $result->phone_verified;
-		$p->email            = $result->email;
-		$p->email_verified   = $result->email_verified;
-		$p->is_competing     = $result->is_competing != 0;
-		$p->is_group_contact = $result->is_team_contact != 0;
-		$p->food             = $result->food;
-		$p->pno              = $result->pno;
-
-		return $p;
-	}
-
 	protected static function to_message( $result ): Message {
 		$m                    = new Message();
 		$m->id                = $result->id;

--- a/src/data/store/GroupDao.php
+++ b/src/data/store/GroupDao.php
@@ -59,7 +59,7 @@ class GroupDao extends AbstractDao {
 
 	function generate_query( $where ) {
 		$age_subquery = function ( $fn, $column_name ) {
-			return '(SELECT ' . $fn . '(DATEDIFF(CURDATE(), STR_TO_DATE(LEFT(PNO, 8), \'%%Y%%m%%d\')) / 365.25)' .
+			return '(SELECT ' . $fn . '(DATEDIFF(CURDATE(), STR_TO_DATE(LEFT(pno, 8), \'%%Y%%m%%d\')) / 365.25)' .
 			       ' FROM wp_tuja_person' .
 			       ' WHERE team_id = g.id' .
 			       ' AND is_competing = TRUE) AS ' . $column_name;

--- a/src/tuja.php
+++ b/src/tuja.php
@@ -239,6 +239,7 @@ abstract class Plugin {
 			self::PATH . '/data/model/' . $classname . '.php',
 			self::PATH . '/util/markdown/' . $classname . '.php',
 			self::PATH . '/util/messaging/' . $classname . '.php',
+			self::PATH . '/util/rules/' . $classname . '.php',
 			self::PATH . '/util/score/' . $classname . '.php',
 			self::PATH . '/util/' . $classname . '.php',
 			self::PATH . '/view/' . $classname . '.php',

--- a/src/util/Template.php
+++ b/src/util/Template.php
@@ -55,7 +55,7 @@ class Template
 
 	public static function group_parameters( Group $group )
     {
-	    $registration_evaluator = new RegistrationEvaluator( $group->competition_id );
+	    $registration_evaluator = new RegistrationEvaluator();
 	    $evaluation_result      = $registration_evaluator->evaluate( $group );
         return [
 	        'group_name' => $group->name,

--- a/src/util/Template.php
+++ b/src/util/Template.php
@@ -5,6 +5,8 @@ namespace tuja\util;
 use tuja\util\markdown\Parsedown;
 use tuja\data\model\Group;
 use tuja\data\model\Person;
+use tuja\util\rules\RegistrationEvaluator;
+use tuja\util\rules\RuleResult;
 
 class Template
 {
@@ -15,7 +17,7 @@ class Template
         $this->content = $content;
     }
 
-    public function render($parameters = array(), $is_markdown = false)
+	public function render( $parameters = array(), $is_markdown = false )
     {
         $rendered_content = $this->content;
         foreach ($parameters as $name => $value) {
@@ -29,14 +31,14 @@ class Template
         }
     }
 
-    public function get_variables()
+	public function get_variables()
     {
         $variables = [];
         preg_match_all('/\{\{([a-zA-Z_]+)\}\}/', $this->content, $variables);
         return array_unique($variables[1]);
     }
 
-    public static function person_parameters(Person $person)
+	public static function person_parameters( Person $person )
     {
         return [
             'person_key' => $person->random_id,
@@ -48,15 +50,33 @@ class Template
         ];
     }
 
-    public static function group_parameters(Group $group)
+	public static function group_parameters( Group $group )
     {
+	    $registration_evaluator = new RegistrationEvaluator( $group->competition_id );
+	    $evaluation_result      = $registration_evaluator->evaluate( $group );
         return [
-            'group_name' => htmlspecialchars($group->name),
-            'group_key' => $group->random_id
+	        'group_name'                             => htmlspecialchars( $group->name ),
+	        'group_key'                              => $group->random_id,
+	        'group_registration_evaluation_warnings' => self::group_parameter_registration_issues( 'Sådant som ni borde fixa:', $evaluation_result, RuleResult::WARNING ),
+	        'group_registration_evaluation_errors'   => self::group_parameter_registration_issues( 'Sådant som ni måste fixa för att få starta:', $evaluation_result, RuleResult::BLOCKER )
         ];
     }
 
-    public static function site_parameters()
+	private static function group_parameter_registration_issues( $header, array $evaluation_result, $status ) {
+		return $header . "\n" . join(
+				"\n",
+				array_map(
+					function ( $issue ) {
+						return sprintf( '- %s. %s', $issue->rule_name, $issue->details );
+					},
+					array_filter(
+						$evaluation_result,
+						function ( $issue ) use ( $status ) {
+							return $issue->status === $status;
+						} ) ) );
+	}
+
+	public static function site_parameters()
     {
         return [
             'base_url' => get_site_url()

--- a/src/util/rules/RegistrationEvaluator.php
+++ b/src/util/rules/RegistrationEvaluator.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace tuja\util\rules;
+
+
+use tuja\data\model\Group;
+use tuja\data\model\GroupCategory;
+use tuja\data\model\Person;
+use tuja\data\store\GroupCategoryDao;
+use tuja\data\store\PersonDao;
+
+class RegistrationEvaluator {
+	private $person_dao;
+	private $group_categories;
+
+	public function __construct( $competition_id ) {
+		$this->person_dao       = new PersonDao();
+		$this->group_categories = $this->get_group_categories( $competition_id );
+	}
+
+	private function get_group_categories( $competition_id ) {
+		$group_category_dao = new GroupCategoryDao();
+		$categories         = $group_category_dao->get_all_in_competition( $competition_id );
+
+		return array_combine( array_map( function ( GroupCategory $category ) {
+			return $category->id;
+		}, $categories ), array_values( $categories ) );
+	}
+
+	public function evaluate( Group $group ) {
+		$group_category = $this->group_categories[ $group->category_id ];
+		$people         = $this->person_dao->get_all_in_group( $group->id );
+
+		return array_merge(
+			self::rule_has_contacts( $people ),
+			self::rule_person_names( $people ),
+			self::rule_contacts_have_phone_and_email( $people ),
+			self::rule_group_size( $people )
+		);
+	}
+
+	private static function rule_has_contacts( array $people ) {
+		$contacts = array_filter( $people, function ( Person $person ) {
+			return $person->is_group_contact;
+		} );
+		switch ( count( $contacts ) ) {
+			case 0:
+				return [ new RuleResult( 'Kontaktperson', RuleResult::BLOCKER, 'Kontaktperson saknas.' ) ];
+			case 1:
+				return [ new RuleResult( 'Kontaktperson', RuleResult::OK, 'En kontaktperson har angivits.' ) ];
+			case 2:
+				return [ new RuleResult( 'Kontaktperson', RuleResult::WARNING, 'Ni har angett att två personer är kontaktpersoner. Vanligtvis räcker det med en.' ) ];
+			default:
+				return [ new RuleResult( 'Kontaktperson', RuleResult::BLOCKER, 'Bara en eller två personer kan vara kontaktpersoner.' ) ];
+		}
+	}
+
+	private static function rule_contacts_have_phone_and_email( array $people ) {
+		$contacts = array_filter( $people, function ( Person $person ) {
+			return $person->is_group_contact;
+		} );
+
+		return array_reduce( $contacts, function ( $carry, Person $person ) {
+			$rule_name = 'Kontaktperson ' . htmlspecialchars( $person->name );
+			if ( ! empty( $person->phone ) ) {
+				if ( Person::is_valid_phone_number( $person->phone ) ) {
+					$carry[] = new RuleResult( $rule_name, RuleResult::OK, 'Telefonnumret till kontaktperson ser rimligt ut.' );
+				} else {
+					$carry[] = new RuleResult( $rule_name, RuleResult::WARNING, 'Telefonnumret till kontaktperson verkar inte vara korrekt.' );
+				}
+			} else {
+				$carry[] = new RuleResult( $rule_name, RuleResult::BLOCKER, 'Kontaktperson måste ha ett telefonnummer.' );
+			}
+			if ( ! empty( $person->email ) ) {
+				if ( Person::is_valid_email_address( $person->email ) ) {
+					$carry[] = new RuleResult( $rule_name, RuleResult::OK, 'E-postadress till kontaktperson ser rimlig ut.' );
+				} else {
+					$carry[] = new RuleResult( $rule_name, RuleResult::WARNING, 'E-postadress till kontaktperson verkar inte vara korrekt.' );
+				}
+			} else {
+				$carry[] = new RuleResult( $rule_name, RuleResult::BLOCKER, 'Kontaktperson måste ha en e-postadress.' );
+			}
+
+			return $carry;
+		}, [] );
+	}
+
+	private static function rule_group_size( array $people ) {
+		$participants = array_filter( $people, function ( Person $person ) {
+			return $person->is_competing;
+		} );
+		if ( count( $participants ) < 4 ) {
+			return [ new RuleResult( 'Antal deltagare', RuleResult::WARNING, 'Ni har färre än fyra deltagare. Det blir lättare, och säkert roligare, om ni är fler.' ) ];
+		} elseif ( count( $participants ) > 8 ) {
+			return [ new RuleResult( 'Antal deltagare', RuleResult::WARNING, 'Vi tycker lag ska ha högst åtta deltagare.' ) ];
+		} else {
+			return [ new RuleResult( 'Antal deltagare', RuleResult::OK, 'Ni verkar ha lagom många deltagare.' ) ];
+		}
+	}
+
+	private static function rule_person_names( array $people ) {
+		$names = array_map( function ( Person $person ) {
+			return trim( $person->name );
+		}, $people );
+		if ( count( $people ) > 1 && count( $names ) != count( array_unique( $names ) ) ) {
+			return [ new RuleResult( 'Deltagarnas namn', RuleResult::WARNING, 'Stämmer det verkligen att några i laget har samma namn?' ) ];
+		} else {
+			return [ new RuleResult( 'Deltagarnas namn', RuleResult::OK, 'Alla deltagare har vettiga namn.' ) ];
+		}
+	}
+
+}

--- a/src/util/rules/RegistrationEvaluator.php
+++ b/src/util/rules/RegistrationEvaluator.php
@@ -61,7 +61,7 @@ class RegistrationEvaluator {
 		} );
 
 		return array_reduce( $contacts, function ( $carry, Person $person ) {
-			$rule_name = 'Kontaktperson ' . htmlspecialchars( $person->name );
+			$rule_name = 'Kontaktpersonen ' . htmlspecialchars( $person->name );
 			if ( ! empty( $person->phone ) ) {
 				if ( Person::is_valid_phone_number( $person->phone ) ) {
 					$carry[] = new RuleResult( $rule_name, RuleResult::OK, 'Telefonnumret till kontaktperson ser rimligt ut.' );

--- a/src/util/rules/RuleResult.php
+++ b/src/util/rules/RuleResult.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace tuja\util\rules;
+
+
+class RuleResult {
+
+	const OK = 'ok';
+	const WARNING = 'warning';
+	const BLOCKER = 'blocker';
+
+	public $rule_name;
+	public $status;
+	public $details;
+
+	public function __construct( $rule_name, $status, $details ) {
+		$this->rule_name = $rule_name;
+		$this->status    = $status;
+		$this->details   = $details;
+	}
+}


### PR DESCRIPTION
Ny finess för att kolla om ett lag uppfyller våra anmälningskriterier. Eftersom en anmälan kan ändras om och om igen så kan det vara bra att ha någon sorts mekanism på adminsidan som kollar om ett lags anmälan verkar vara komplett eller ej.

Funktioner:
- RegistrationEvaluator.php innehåller de regler som lagen ska uppfylla. En del regler är "krav" och en del är "rekommendationer". Se även #57.
- Group.php på adminsidan kollar dessa regler och skriver ut vilka som ett lag uppfyller respektive inte uppfyller.
- MessagesSend.php har ett nytt "filter" för att välja ut grupper som inte uppfyller alla regler.
- Template.php har utökats med stöd för {{group_registration_evaluation_warnings}} och {{group_registration_evaluation_errors}} så att vi kan skicka ut brev till lagledarna för lagen som inte uppfyller alla våra krav och önskemål. Se även #58.