### PR TITLE
Send messages to both non-competing people and team contacts #69

### DIFF
--- a/src/admin/views/messages-send.php
+++ b/src/admin/views/messages-send.php
@@ -124,6 +124,13 @@ if ( ! empty( $action_result ) ) {
 	$variables        = $action_result['variables'];
 	$body_template    = $action_result['body_template'];
 	$subject_template = $action_result['subject_template'];
+	$warnings         = $action_result['warnings'];
+
+	if ( count( $warnings ) > 0 ) {
+		foreach ( $warnings as $warning ) {
+			AdminUtils::printError( $warning );
+		}
+	}
 
 	$variables_headers_html = join( array_map( function ( $variable ) {
 		return sprintf( '<td><strong>%s</strong></td>', $variable );


### PR DESCRIPTION
Det kan vara bra med ett sätt att skicka meddelanden till både "medföljande vuxna och lagledare" utifall att laget, innan anmälan är komplett, har medföljande vuxen angiven men ännu ingen lagledare (utifall att en ledare har anmält sina scouter som en patrull men ännu inte fyllt i alla scouternas personuppgifter).