### PR TITLE
Points limit on question group

### DIFF
--- a/src/admin/AdminUtils.php
+++ b/src/admin/AdminUtils.php
@@ -3,6 +3,7 @@
 namespace tuja\admin;
 
 use Exception;
+use tuja\util\ImageManager;
 
 class AdminUtils
 {
@@ -57,5 +58,21 @@ class AdminUtils
 		}
 
 		printf( '<nav class="tuja">%s</nav>', join( ' | ', $menu ) );
+	}
+
+	public static function get_image_thumbnails_html( $answer, $group_key = null ) {
+		$answer = json_decode($answer, true);
+		if (empty($answer['images'])) {
+			return '';
+		}
+
+		$image_manager = new ImageManager();
+
+		return join( array_map( function ( $image_id ) use ( $image_manager, $group_key ) {
+			$resized_image_url = $image_manager->get_resized_image_url( $image_id, 200 * 200, $group_key );
+
+			// TODO: Show fullsize image in modal popup when clicking image (see https://codex.wordpress.org/ThickBox)
+			return $resized_image_url ? sprintf( '<img src="%s">', $resized_image_url ) : 'Kan inte visa bild.';
+		}, $answer['images'] ) );
 	}
 }

--- a/src/admin/Form.php
+++ b/src/admin/Form.php
@@ -65,6 +65,9 @@ class Form {
 						case 'sort_order':
 							$updated_groups[$id]->sort_order = $field_value;
 							break;
+						case 'score_max':
+							$updated_groups[$id]->score_max = is_numeric($field_value) ? floatval($field_value) : null;
+							break;
 					}
 				}
 			}

--- a/src/admin/Group.php
+++ b/src/admin/Group.php
@@ -74,7 +74,14 @@ class Group {
 
 		$group = $this->group;
 
-		$score_calculator = new ScoreCalculator( $competition->id, $db_question, $db_question_group, $db_response, $db_groups, $db_points );
+		$score_calculator = new ScoreCalculator(
+			$competition->id,
+			$db_question,
+			$db_question_group,
+			$db_response,
+			$db_groups,
+			$db_points
+		);
 		$score_result     = $score_calculator->score( $group->id );
 
 		$responses                     = $db_response->get_latest_by_group( $group->id );

--- a/src/admin/Group.php
+++ b/src/admin/Group.php
@@ -21,16 +21,16 @@ class Group {
 
 	public function __construct() {
 		$db_groups   = new GroupDao();
-		$this->group = $db_groups->get($_GET['tuja_group']);
-		if (!$this->group) {
+		$this->group = $db_groups->get( $_GET['tuja_group'] );
+		if ( ! $this->group ) {
 			print 'Could not find group';
 
 			return;
 		}
 
 		$db_competition    = new CompetitionDao();
-		$this->competition = $db_competition->get($this->group->competition_id);
-		if (!$this->competition) {
+		$this->competition = $db_competition->get( $this->group->competition_id );
+		if ( ! $this->competition ) {
 			print 'Could not find competition';
 
 			return;
@@ -39,17 +39,19 @@ class Group {
 
 
 	public function handle_post() {
-		if(!isset($_POST['tuja_points_action'])) return;
+		if ( ! isset( $_POST['tuja_points_action'] ) ) {
+			return;
+		}
 
 		if ( $_POST['tuja_points_action'] === 'save' ) {
 			$db_question = new QuestionDao();
 			$db_points   = new PointsDao();
 
-			$questions = $db_question->get_all_in_competition($this->competition->id);
-			foreach($questions as $question) {
+			$questions = $db_question->get_all_in_competition( $this->competition->id );
+			foreach ( $questions as $question ) {
 				$value = $_POST[ 'tuja_group_points__' . $question->id ];
-				if(isset($value)) {
-					$db_points->set($this->group->id, $question->id, is_numeric($value) ? intval($value) : null);
+				if ( isset( $value ) ) {
+					$db_points->set( $this->group->id, $question->id, is_numeric( $value ) ? intval( $value ) : null );
 				}
 			}
 		}
@@ -59,7 +61,7 @@ class Group {
 	public function output() {
 		$this->handle_post();
 
-		$competition     = $this->competition;
+		$competition = $this->competition;
 
 		$db_form           = new FormDao();
 		$forms             = $db_form->get_all_in_competition( $competition->id );
@@ -70,30 +72,26 @@ class Group {
 		$db_points         = new PointsDao();
 		$db_message        = new MessageDao();
 
-		$group                               = $this->group;
+		$group = $this->group;
 
-		$score_calculator                    = new ScoreCalculator( $competition->id, $db_question, $db_question_group, $db_response, $db_groups, $db_points );
-		// TODO: Return ScoreResult with all data from score() instead of having two different methods with different arguments.
-		$calculated_scores_final             = $score_calculator->score_per_question( $group->id );
-		$calculated_scores_without_overrides = $score_calculator->score_per_question( $group->id, false );
-		$questions_score                     = $score_calculator->score( $group->id, false );
-		$final_score                         = $score_calculator->score( $group->id, true );
+		$score_calculator = new ScoreCalculator( $competition->id, $db_question, $db_question_group, $db_response, $db_groups, $db_points );
+		$score_result     = $score_calculator->score( $group->id );
 
-		$responses                           = $db_response->get_latest_by_group( $group->id );
-		$response_per_question               = array_combine( array_map( function ( $response ) {
+		$responses                     = $db_response->get_latest_by_group( $group->id );
+		$response_per_question         = array_combine( array_map( function ( $response ) {
 			return $response->form_question_id;
-		}, $responses), array_values($responses));
-		$points_overrides                    = $db_points->get_by_group( $group->id );
-		$points_overrides_per_question       = array_combine( array_map( function ( $points ) {
+		}, $responses ), array_values( $responses ) );
+		$points_overrides              = $db_points->get_by_group( $group->id );
+		$points_overrides_per_question = array_combine( array_map( function ( $points ) {
 			return $points->form_question_id;
-		}, $points_overrides), array_values($points_overrides));
+		}, $points_overrides ), array_values( $points_overrides ) );
 
 		$person_dao = new PersonDao();
-		$people = $person_dao->get_all_in_group( $group->id );
+		$people     = $person_dao->get_all_in_group( $group->id );
 
 		$registration_evaluator  = new RegistrationEvaluator();
 		$registration_evaluation = $registration_evaluator->evaluate( $group );
 
-		include('views/group.php');
+		include( 'views/group.php' );
 	}
 }

--- a/src/admin/Group.php
+++ b/src/admin/Group.php
@@ -6,6 +6,7 @@ use tuja\data\store\CompetitionDao;
 use tuja\data\store\FormDao;
 use tuja\data\store\MessageDao;
 use tuja\data\store\PersonDao;
+use tuja\data\store\QuestionGroupDao;
 use tuja\util\rules\RegistrationEvaluator;
 use tuja\data\store\QuestionDao;
 use tuja\data\store\PointsDao;
@@ -60,18 +61,24 @@ class Group {
 
 		$competition     = $this->competition;
 
-		$db_form     = new FormDao();
-		$forms       = $db_form->get_all_in_competition( $competition->id );
-		$db_question = new QuestionDao();
-		$db_response = new ResponseDao();
-		$db_groups   = new GroupDao();
-		$db_points   = new PointsDao();
-		$db_message  = new MessageDao();
+		$db_form           = new FormDao();
+		$forms             = $db_form->get_all_in_competition( $competition->id );
+		$db_question       = new QuestionDao();
+		$db_question_group = new QuestionGroupDao();
+		$db_response       = new ResponseDao();
+		$db_groups         = new GroupDao();
+		$db_points         = new PointsDao();
+		$db_message        = new MessageDao();
 
-		$score_calculator                    = new ScoreCalculator( $competition->id, $db_question, $db_response, $db_groups, $db_points );
 		$group                               = $this->group;
+
+		$score_calculator                    = new ScoreCalculator( $competition->id, $db_question, $db_question_group, $db_response, $db_groups, $db_points );
+		// TODO: Return ScoreResult with all data from score() instead of having two different methods with different arguments.
 		$calculated_scores_final             = $score_calculator->score_per_question( $group->id );
 		$calculated_scores_without_overrides = $score_calculator->score_per_question( $group->id, false );
+		$questions_score                     = $score_calculator->score( $group->id, false );
+		$final_score                         = $score_calculator->score( $group->id, true );
+
 		$responses                           = $db_response->get_latest_by_group( $group->id );
 		$response_per_question               = array_combine( array_map( function ( $response ) {
 			return $response->form_question_id;

--- a/src/admin/views/group.php
+++ b/src/admin/views/group.php
@@ -31,10 +31,10 @@ AdminUtils::printTopMenu( $competition );
 
     <h3>Svar och poäng</h3>
     <p>
-        <strong>Totalt <?= $final_score ?> poäng.</strong>
+        <strong>Totalt <?= $score_result->total_final ?> poäng.</strong>
 		<?php
-		if ( $questions_score != $final_score ) {
-			printf( '%d poäng har dragits av pga. att maximal poäng uppnåtts på vissa frågegrupper.', $questions_score - $final_score );
+		if ( $score_result->total_without_question_group_max_limits != $score_result->total_final ) {
+			printf( '%d poäng har dragits av pga. att maximal poäng uppnåtts på vissa frågegrupper.', $score_result->total_without_question_group_max_limits - $score_result->total_final );
 		}
 		?>
     </p>
@@ -61,8 +61,13 @@ AdminUtils::printTopMenu( $competition );
 	        printf( '<tr class="tuja-admin-review-form-row"><td colspan="6"><strong>%s</strong></td></tr>', $form->name );
             $questions = $db_question->get_all_in_form($form->id);
             foreach ($questions as $question) {
-                $calculated_score_without_override = $calculated_scores_without_overrides[$question->id] ?: 0;
-                $calculated_score_final = $calculated_scores_final[$question->id] ?: 0;
+
+	            $calculated_score_without_override = isset( $score_result->questions[ $question->id ] )
+		            ? $score_result->questions[ $question->id ]->auto
+		            : 0;
+	            $calculated_score_final            = isset( $score_result->questions[ $question->id ] )
+		            ? $score_result->questions[ $question->id ]->final
+		            : 0;
 
                 $field_value = isset($points) && $points->created > $response->created ? $points->points : '';
                 $response = $response_per_question[$question->id]; // TODO: One line to late?

--- a/src/admin/views/group.php
+++ b/src/admin/views/group.php
@@ -34,7 +34,8 @@ AdminUtils::printTopMenu( $competition );
         <strong>Totalt <?= $score_result->total_final ?> poäng.</strong>
 		<?php
 		if ( $score_result->total_without_question_group_max_limits != $score_result->total_final ) {
-			printf( '%d poäng har dragits av pga. att maximal poäng uppnåtts på vissa frågegrupper.', $score_result->total_without_question_group_max_limits - $score_result->total_final );
+			printf( '%d poäng har dragits av pga. att maximal poäng uppnåtts på vissa frågegrupper.',
+				$score_result->total_without_question_group_max_limits - $score_result->total_final );
 		}
 		?>
     </p>
@@ -76,13 +77,12 @@ AdminUtils::printTopMenu( $competition );
                     ? $points_overrides_per_question[$question->id]->points
                     : '';
 
-                // TODO: Rewrite is a hack for getting HTML into $response->answers
+	            // TODO: Rewrite this hack for getting HTML into $response->answers
                 if (is_array($response->answers) && $question->type == 'images') {
-                    $field = new FieldImages($question->possible_answers ?: $question->correct_answers);
                     // For each user-provided answer, render the photo description and a photo thumbnail:
 	                $group_key         = $group->random_id;
-	                $response->answers = array_map( function ( $answer ) use ( $field, $group_key ) {
-		                return $field->render_admin_preview( $answer, $group_key );
+	                $response->answers = array_map( function ( $answer ) use ( $group_key ) {
+		                return AdminUtils::get_image_thumbnails_html( $answer, $group_key );
                     }, $response->answers);
                 }
 
@@ -156,10 +156,9 @@ AdminUtils::printTopMenu( $competition );
         $messages = $db_message->get_by_group($group->id);
         foreach ($messages as $message) {
             if (is_array($message->image_ids)) {
-                $field = new FieldImages([]);
                 // For each user-provided answer, render the photo description and a photo thumbnail:
-                $images = array_map(function ($image_id) use ($field) {
-                    return $field->render_admin_preview("$image_id,,");
+                $images = array_map(function ($image_id) {
+	                return AdminUtils::get_image_thumbnails_html( [ 'images' => [ $image_id ] ], null );
                 }, $message->image_ids);
             }
 

--- a/src/admin/views/group.php
+++ b/src/admin/views/group.php
@@ -30,7 +30,14 @@ AdminUtils::printTopMenu( $competition );
 	?>
 
     <h3>Svar och poäng</h3>
-    <p><strong>Totalt <?= array_sum($calculated_scores_final) ?> poäng.</strong></p>
+    <p>
+        <strong>Totalt <?= $final_score ?> poäng.</strong>
+		<?php
+		if ( $questions_score != $final_score ) {
+			printf( '%d poäng har dragits av pga. att maximal poäng uppnåtts på vissa frågegrupper.', $questions_score - $final_score );
+		}
+		?>
+    </p>
 
     <table class="tuja-admin-review">
         <thead>
@@ -64,11 +71,13 @@ AdminUtils::printTopMenu( $competition );
                     ? $points_overrides_per_question[$question->id]->points
                     : '';
 
+                // TODO: Rewrite is a hack for getting HTML into $response->answers
                 if (is_array($response->answers) && $question->type == 'images') {
                     $field = new FieldImages($question->possible_answers ?: $question->correct_answers);
                     // For each user-provided answer, render the photo description and a photo thumbnail:
-                    $response->answers = array_map(function ($answer) use ($field) {
-                        return $field->render_admin_preview($answer);
+	                $group_key         = $group->random_id;
+	                $response->answers = array_map( function ( $answer ) use ( $field, $group_key ) {
+		                return $field->render_admin_preview( $answer, $group_key );
                     }, $response->answers);
                 }
 

--- a/src/admin/views/group.php
+++ b/src/admin/views/group.php
@@ -89,12 +89,12 @@ AdminUtils::printTopMenu( $competition );
 	            $score_class = $question->score_max > 0 ? AdminUtils::getScoreCssClass( $calculated_score_without_override / $question->score_max ) : '';
 
 	            printf( '' .
-	                    '<tr class="tuja-admin-review-response-row"><td></td>' .
+                    '<tr class="tuja-admin-review-response-row"><td></td>' .
                     '  <td valign="top">%s</td>' .
                     '  <td valign="top">%s</td>' .
                     '  <td valign="top">%s</td>' .
                     '  <td valign="top"><span class="tuja-admin-review-autoscore %s">%s p</span></td>' .
-                    '  <td valign="top"><input type="text" name="%s" value="%s" size="5"></td>' .
+                    '  <td valign="top"><input type="number" name="%s" value="%s" size="5" min="0" max="%d"> p</td>' .
                     '</tr>',
                     $question->text,
 		            join( '<br>', $question->correct_answers ),
@@ -102,7 +102,8 @@ AdminUtils::printTopMenu( $competition );
 		            $score_class,
                     $calculated_score_without_override,
                     'tuja_group_points__' . $question->id,
-		            $points_override );
+		            $points_override,
+		            $question->score_max ?: 1000 );
             }
         }
         ?>

--- a/src/admin/views/messages.php
+++ b/src/admin/views/messages.php
@@ -37,7 +37,7 @@ printf('<p><a href="%s">Skicka meddelanden</a></p>', $import_url);
             $field = new FieldImages([]);
             // For each user-provided answer, render the photo description and a photo thumbnail:
             $images = array_map(function ($image_id) use ($field) {
-                return $field->render_admin_preview("$image_id,,");
+                return AdminUtils::get_image_thumbnails_html( [ 'images' => [ $image_id ] ], null );
             }, $message->image_ids);
         } else {
             $images = [];

--- a/src/admin/views/review.php
+++ b/src/admin/views/review.php
@@ -62,8 +62,9 @@ AdminUtils::printTopMenu( $competition );
                             if (is_array($response->answers) && $question->type == 'images') {
                                 $field = new FieldImages($question->possible_answers ?: $question->correct_answers);
                                 // For each user-provided answer, render the photo description and a photo thumbnail:
-                                $response->answers = array_map(function ($answer) use ($field) {
-                                    return $field->render_admin_preview($answer);
+	                            $group_key = $groups_map[ $response->group_id ]->random_id;
+                                $response->answers = array_map(function ($answer) use ($field, $group_key) {
+                                    return $field->render_admin_preview($answer, $group_key);
                                 }, $response->answers);
                             }
 

--- a/src/admin/views/review.php
+++ b/src/admin/views/review.php
@@ -60,12 +60,11 @@ AdminUtils::printTopMenu( $competition );
                             $field_value = isset($points) && $points->created > $response->created ? $points->points : '';
 
                             if (is_array($response->answers) && $question->type == 'images') {
-                                $field = new FieldImages($question->possible_answers ?: $question->correct_answers);
                                 // For each user-provided answer, render the photo description and a photo thumbnail:
 	                            $group_key = $groups_map[ $response->group_id ]->random_id;
-                                $response->answers = array_map(function ($answer) use ($field, $group_key) {
-                                    return $field->render_admin_preview($answer, $group_key);
-                                }, $response->answers);
+	                            $response->answers = array_map( function ( $answer ) use ( $group_key ) {
+		                            return AdminUtils::get_image_thumbnails_html( $answer, $group_key );
+	                            }, $response->answers);
                             }
 
 	                        $group_url = add_query_arg( array(

--- a/src/admin/views/scoreboard.php
+++ b/src/admin/views/scoreboard.php
@@ -4,6 +4,7 @@ use tuja\data\store\GroupCategoryDao;
 use tuja\data\store\GroupDao;
 use tuja\data\store\PointsDao;
 use tuja\data\store\QuestionDao;
+use tuja\data\store\QuestionGroupDao;
 use tuja\data\store\ResponseDao;
 use tuja\util\score\ScoreCalculator;
 
@@ -17,6 +18,7 @@ AdminUtils::printTopMenu( $competition );
 		$calculator  = new ScoreCalculator(
 			$competition->id,
 			new QuestionDao(),
+			new QuestionGroupDao(),
 			new ResponseDao(),
 			new GroupDao(),
 			new PointsDao() );

--- a/src/assets/css/admin.css
+++ b/src/assets/css/admin.css
@@ -147,6 +147,11 @@ tr.tuja-admin-review-correctanswer-row td:first-child,
 tr.tuja-admin-review-response-row td:first-child {
     border-top: none;
 }
+
+.tuja-admin-review-response-row input[type=number] {
+    width: 4em;
+}
+
 span.tuja-admin-review-autoscore {
     display: inline-block;
     border-radius: 3px;

--- a/src/data/model/QuestionGroup.php
+++ b/src/data/model/QuestionGroup.php
@@ -9,11 +9,14 @@ class QuestionGroup {
 	public $form_id;
 	public $text;
 	public $sort_order;
-	public $score_max = 20; // TODO: Make configurable and persistable
+	public $score_max;
 
 	public function validate() {
 		if ( strlen( $this->text ) > 65000 ) {
 			throw new ValidationException( 'text', 'Frågegruppens text är för lång.' );
+		}
+		if ( isset( $this->score_max ) && $this->score_max < 0 ) {
+			throw new ValidationException( 'score_max', 'Maximal poäng måste vara mer än 0.' );
 		}
 	}
 }

--- a/src/data/model/QuestionGroup.php
+++ b/src/data/model/QuestionGroup.php
@@ -9,6 +9,7 @@ class QuestionGroup {
 	public $form_id;
 	public $text;
 	public $sort_order;
+	public $score_max = 20; // TODO: Make configurable and persistable
 
 	public function validate() {
 		if ( strlen( $this->text ) > 65000 ) {

--- a/src/data/store/QuestionGroupDao.php
+++ b/src/data/store/QuestionGroupDao.php
@@ -12,6 +12,17 @@ class QuestionGroupDao extends AbstractDao {
 		$this->table = Database::get_table( 'form_question_group' );
 	}
 
+	private static function get_config_string( QuestionGroup $question_group ) {
+		return json_encode( array(
+			'score_max' => floatval( $question_group->score_max )
+		) );
+	}
+
+	private static function set_config( QuestionGroup $question_group, $json_string ) {
+		$conf                      = json_decode( $json_string, true );
+		$question_group->score_max = $conf['score_max'];
+	}
+
 	function create( QuestionGroup $group ) {
 		$group->validate();
 
@@ -20,13 +31,15 @@ class QuestionGroupDao extends AbstractDao {
 				'random_id'  => $this->id->random_string(),
 				'form_id'    => $group->form_id,
 				'text'       => $group->text,
-				'sort_order' => $group->sort_order
+				'sort_order' => $group->sort_order,
+				'config'     => self::get_config_string( $group )
 			),
 			array(
 				'%s',
 				'%d',
 				'%s',
-				'%d'
+				'%d',
+				'%s'
 			) );
 		$success       = $affected_rows !== false && $affected_rows === 1;
 
@@ -45,7 +58,8 @@ class QuestionGroupDao extends AbstractDao {
 		return $this->wpdb->update( $this->table,
 			array(
 				'text'       => $group->text,
-				'sort_order' => $group->sort_order
+				'sort_order' => $group->sort_order,
+				'config'     => self::get_config_string( $group )
 			),
 			array(
 				'id' => $group->id
@@ -96,6 +110,7 @@ class QuestionGroupDao extends AbstractDao {
 		$q->random_id  = $result->random_id;
 		$q->text       = $result->text;
 		$q->sort_order = $result->sort_order;
+//		self::set_config( $q, $result->config );
 
 		return $q;
 	}

--- a/src/data/store/QuestionGroupDao.php
+++ b/src/data/store/QuestionGroupDao.php
@@ -14,13 +14,18 @@ class QuestionGroupDao extends AbstractDao {
 
 	private static function get_config_string( QuestionGroup $question_group ) {
 		return json_encode( array(
-			'score_max' => floatval( $question_group->score_max )
+			'score_max' => isset( $question_group->score_max )
+				? floatval( $question_group->score_max )
+				: null
 		) );
 	}
 
 	private static function set_config( QuestionGroup $question_group, $json_string ) {
-		$conf                      = json_decode( $json_string, true );
-		$question_group->score_max = $conf['score_max'];
+		$conf = json_decode( $json_string, true );
+
+		$question_group->score_max = isset( $conf['score_max'] )
+			? $conf['score_max']
+			: null;
 	}
 
 	function create( QuestionGroup $group ) {
@@ -66,15 +71,14 @@ class QuestionGroupDao extends AbstractDao {
 			) );
 	}
 
-	function get($id)
-    {
-        return $this->get_object(
-            function ($row) {
-                return self::to_question_group($row);
-            },
-            'SELECT * FROM ' . $this->table . ' WHERE id = %d',
-            $id);
-    }
+	function get( $id ) {
+		return $this->get_object(
+			function ( $row ) {
+				return self::to_question_group( $row );
+			},
+			'SELECT * FROM ' . $this->table . ' WHERE id = %d',
+			$id );
+	}
 
 	function get_all_in_form( $form_id ) {
 		return $this->get_objects(
@@ -110,7 +114,7 @@ class QuestionGroupDao extends AbstractDao {
 		$q->random_id  = $result->random_id;
 		$q->text       = $result->text;
 		$q->sort_order = $result->sort_order;
-//		self::set_config( $q, $result->config );
+		self::set_config( $q, $result->config );
 
 		return $q;
 	}

--- a/src/tuja.php
+++ b/src/tuja.php
@@ -129,7 +129,8 @@ abstract class Plugin
 				random_id  VARCHAR(20)  NOT NULL,
 				form_id    INTEGER      NOT NULL,
 				text       TEXT,
-				sort_order SMALLINT
+				sort_order SMALLINT,
+				config     TEXT
 			) " . $charset;
 
 		$tables[] = "

--- a/src/util/ImageManager.php
+++ b/src/util/ImageManager.php
@@ -50,14 +50,17 @@ class ImageManager
         }
     }
 
-    public function get_resized_image_url($file_id, $pixels)
+	public function get_resized_image_url( $file_id, $pixels, $group_key = null )
     {
-        $dst_filename = "$file_id-$pixels.jpg";
-        $dst_path = $this->directory . $dst_filename;
+	    list ( $file_id, $ext ) = explode( '.', $file_id );
+	    $dst_filename  = "$file_id-$pixels.$ext";
+	    $sub_directory = isset( $group_key ) ? "group-$group_key/" : '';
+	    $dst_path      = $this->directory . $sub_directory . $dst_filename;
         if (file_exists($dst_path)) {
-            return $this->public_url_directory . $dst_filename;
+	        return $this->public_url_directory . $sub_directory . $dst_filename;
         }
-        $src_path = $this->directory . "$file_id.jpg";
+
+	    $src_path  = $this->directory . $sub_directory . "$file_id.$ext";
         $src_image = @imagecreatefromjpeg($src_path);
         if ($src_image !== false) {
             list($width, $height) = getimagesize($src_path);
@@ -66,7 +69,7 @@ class ImageManager
             $dst_image = imagecreatetruecolor($dst_width, $dst_height);
             if (@imagecopyresampled($dst_image, $src_image, 0, 0, 0, 0, $dst_width, $dst_height, $width, $height)) {
                 if (@imagejpeg($dst_image, $dst_path)) {
-                    return $this->public_url_directory . $dst_filename;
+	                return $this->public_url_directory . $sub_directory . $dst_filename;
                 }
             }
         }

--- a/src/util/score/ScoreCalculator.php
+++ b/src/util/score/ScoreCalculator.php
@@ -63,7 +63,7 @@ class ScoreCalculator
 		// ...and then map question group id to the maximum score per question group, for easy access.
 		$question_group_max = [];
 		foreach ( $this->question_groups as $question_group ) {
-			$question_group_max[ $question_group->id ] = $question_group->score_max;
+			$question_group_max[ $question_group->id ] = $question_group->score_max ?: PHP_INT_MAX;
 		}
 
 		// Count how many points the team has been awarded for each question group:

--- a/src/util/score/ScoreCalculator.php
+++ b/src/util/score/ScoreCalculator.php
@@ -34,70 +34,81 @@ class ScoreCalculator
 		$this->questions       = $question_dao->get_all_in_competition( $competition_id );
 	}
 
-	public function score( $group_id, $account_for_group_max = false ) {
-		$question_score = $this->score_per_question( $group_id );
+	public function score( $group_id ): ScoreResult {
+		$result            = new ScoreResult();
+		$result->questions = $this->score_per_question( $group_id );
 
-		if ( $account_for_group_max ) {
-			// TODO: Extract some of this code to separate function
-			$sum_per_question_group = [];
+		$result->total_final = $this->calculate_total_final( $result );
 
-			$question_group_map = [];
-			foreach ( $this->questions as $question ) {
-				$question_group_map[ $question->id ] = $question->question_group_id;
-			}
-			$question_group_max = [];
-			foreach ( $this->question_groups as $question_group ) {
-				$question_group_max[ $question_group->id ] = $question_group->score_max;
-			}
-			foreach ( $question_score as $question_id => $score ) {
-				$question_group_id = $question_group_map[ $question_id ];
-				if ( ! isset( $sum_per_question_group[ $question_group_id ] ) ) {
-					$sum_per_question_group[ $question_group_id ] = 0;
-				}
-				$sum_per_question_group[ $question_group_id ] += $score;
-			}
+		$result->total_without_question_group_max_limits = $this->calculate_total_without_question_group_max_limits( $result );
 
-			$sum = 0;
-			foreach ( $sum_per_question_group as $question_group_id => $group_sum ) {
-				$sum += min( $group_sum, $question_group_max[ $question_group_id ] );
-			}
-
-			return $sum;
-		} else {
-			return array_sum( $question_score );
-		}
-
+		return $result;
 	}
 
-	/**
-	 * Calculates total score for a single team.
-	 */
-	public function score_per_question( $group_id, $consider_overrides = true ) {
-		$points_overrides = array();
-		if ( $consider_overrides ) {
-			$points           = $this->points_dao->get_by_group( $group_id );
-			$points_overrides = array_combine( array_map( function ( $points ) {
-				return $points->form_question_id;
-			}, $points ), $points );
+	private function calculate_total_without_question_group_max_limits( ScoreResult $result ) {
+		return array_sum( array_map( function ( ScoreQuestionResult $question_result ) {
+			return $question_result->final;
+		}, $result->questions ) );
+	}
+
+	private function calculate_total_final( ScoreResult $result ) {
+		$sum_per_question_group = [];
+
+		// Start by mapping a question id to a question group id, for easy access.
+		$question_group_map = [];
+		foreach ( $this->questions as $question ) {
+			$question_group_map[ $question->id ] = $question->question_group_id;
 		}
 
+		// ...and then map question group id to the maximum score per question group, for easy access.
+		$question_group_max = [];
+		foreach ( $this->question_groups as $question_group ) {
+			$question_group_max[ $question_group->id ] = $question_group->score_max;
+		}
+
+		// Count how many points the team has been awarded for each question group:
+		foreach ( $result->questions as $question_id => $score ) {
+			$question_group_id = $question_group_map[ $question_id ];
+			if ( ! isset( $sum_per_question_group[ $question_group_id ] ) ) {
+				$sum_per_question_group[ $question_group_id ] = 0;
+			}
+			$sum_per_question_group[ $question_group_id ] += $score->final;
+		}
+
+		// ...and then sum up all the points, taking into account the maximum number of points per question group:
+		$sum = 0;
+		foreach ( $sum_per_question_group as $question_group_id => $group_sum ) {
+			$sum += min( $group_sum, $question_group_max[ $question_group_id ] );
+		}
+
+		return $sum;
+	}
+
+	private function score_per_question( $group_id ) {
+		$points           = $this->points_dao->get_by_group( $group_id );
+		$points_overrides = array_combine( array_map( function ( $points ) {
+			return $points->form_question_id;
+		}, $points ), $points );
 		$scores    = [];
 		$responses = $this->response_dao->get_latest_by_group( $group_id );
 
 		foreach ( $this->questions as $question ) {
+			$question_result = new ScoreQuestionResult();
 			if ( isset( $responses[ $question->id ] ) ) {
 				$answers = $responses[ $question->id ]->answers;
 				// TODO: How should the is_reviewed flag be used? Only count points for answers where is_reviewed = true?
 				if ( isset( $answers ) ) {
-					$scores[ $question->id ] = $question->score( $answers );
+					$question_result->auto  = $question->score( $answers );
+					$question_result->final = $question_result->auto;
 				}
 			}
-			if ( $consider_overrides
-			     && isset( $points_overrides[ $question->id ] )
+			if ( isset( $points_overrides[ $question->id ] )
 			     && isset( $responses[ $question->id ] )
 			     && $points_overrides[ $question->id ]->created > $responses[ $question->id ]->created ) {
-				$scores[ $question->id ] = $points_overrides[ $question->id ]->points;
+				$question_result->override = $points_overrides[ $question->id ]->points;
+				$question_result->final    = $question_result->override;
 			}
+			$scores[ $question->id ] = $question_result;
 		}
 
 		return $scores;
@@ -107,11 +118,14 @@ class ScoreCalculator
 		$result = [];
 		$groups = $this->group_dao->get_all_in_competition( $this->competition_id );
 		foreach ( $groups as $group ) {
+
+			$score_result = $this->score( $group->id );
+
 			$group_result = [];
 			// TODO: Return proper objects instead of associative arrays.
 			$group_result['group_id']   = $group->id;
 			$group_result['group_name'] = $group->name;
-			$group_result['score']      = $this->score( $group->id, true );
+			$group_result['score']      = $score_result->total_final;
 			$result[]                   = $group_result;
 		}
 

--- a/src/util/score/ScoreCalculator.php
+++ b/src/util/score/ScoreCalculator.php
@@ -2,77 +2,119 @@
 
 namespace tuja\util\score;
 
+use tuja\data\model\Question;
+use tuja\data\store\GroupDao;
+use tuja\data\store\PointsDao;
+use tuja\data\store\QuestionDao;
+use tuja\data\store\QuestionGroupDao;
+use tuja\data\store\ResponseDao;
+
 class ScoreCalculator
 {
-    private $competition_id;
-    private $question_dao;
-    private $response_dao;
-    private $group_dao;
-    private $points_dao;
+	private $competition_id;
+	private $response_dao;
+	private $group_dao;
+	private $points_dao;
+	private $question_groups;
+	private $questions;
 
-    public function __construct($competition_id, $question_dao, $response_dao, $group_dao, $points_dao)
-    {
-        $this->competition_id = $competition_id;
-        $this->question_dao = $question_dao;
-        $this->response_dao = $response_dao;
-        $this->group_dao = $group_dao;
-        $this->points_dao = $points_dao;
-    }
+	public function __construct(
+		$competition_id,
+		QuestionDao $question_dao,
+		QuestionGroupDao $question_group_dao,
+		ResponseDao $response_dao,
+		GroupDao $group_dao,
+		PointsDao $points_dao
+	) {
+		$this->competition_id  = $competition_id;
+		$this->response_dao    = $response_dao;
+		$this->group_dao       = $group_dao;
+		$this->points_dao      = $points_dao;
+		$this->question_groups = $question_group_dao->get_all_in_competition( $competition_id );
+		$this->questions       = $question_dao->get_all_in_competition( $competition_id );
+	}
 
-    public function score($group_id)
-    {
-        return array_sum($this->score_per_question($group_id));
-    }
+	public function score( $group_id, $account_for_group_max = false ) {
+		$question_score = $this->score_per_question( $group_id );
 
-    /**
-     * Calculates total score for a single team.
-     */
-    public function score_per_question($group_id, $consider_overrides = true)
-    {
-	    $points_overrides = array();
-	    if ( $consider_overrides ) {
-		    $points           = $this->points_dao->get_by_group($group_id);
-		    $points_overrides = array_combine(array_map(function ($points) {
-			    return $points->form_question_id;
-		    }, $points), $points);
-	    }
+		if ( $account_for_group_max ) {
+			// TODO: Extract some of this code to separate function
+			$sum_per_question_group = [];
 
-        $scores = [];
-        $responses = $this->response_dao->get_latest_by_group($group_id);
+			$question_group_map = [];
+			foreach ( $this->questions as $question ) {
+				$question_group_map[ $question->id ] = $question->question_group_id;
+			}
+			$question_group_max = [];
+			foreach ( $this->question_groups as $question_group ) {
+				$question_group_max[ $question_group->id ] = $question_group->score_max;
+			}
+			foreach ( $question_score as $question_id => $score ) {
+				$question_group_id = $question_group_map[ $question_id ];
+				if ( ! isset( $sum_per_question_group[ $question_group_id ] ) ) {
+					$sum_per_question_group[ $question_group_id ] = 0;
+				}
+				$sum_per_question_group[ $question_group_id ] += $score;
+			}
 
-        // TODO: Cache response of get_all_in_competition? (Unnecessary to call it once per team.)
-        $questions = $this->question_dao->get_all_in_competition($this->competition_id);
-        foreach ($questions as $question) {
-	        if ( isset( $responses[ $question->id ] ) ) {
-		        $answers = $responses[ $question->id ]->answers;
-		        // TODO: How should the is_reviewed flag be used? Only count points for answers where is_reviewed = true?
-		        if ( isset( $answers ) ) {
-			        $scores[ $question->id ] = $question->score( $answers );
-		        }
-	        }
-	        if ( $consider_overrides
-	             && isset( $points_overrides[ $question->id ] )
-	             && isset( $responses[ $question->id ] )
-	             && $points_overrides[ $question->id ]->created > $responses[ $question->id ]->created ) {
-                $scores[$question->id] = $points_overrides[$question->id]->points;
-            }
-        }
+			$sum = 0;
+			foreach ( $sum_per_question_group as $question_group_id => $group_sum ) {
+				$sum += min( $group_sum, $question_group_max[ $question_group_id ] );
+			}
 
-        return $scores;
-    }
+			return $sum;
+		} else {
+			return array_sum( $question_score );
+		}
 
-    public function score_board()
-    {
-        $result = [];
-        $groups = $this->group_dao->get_all_in_competition($this->competition_id);
-        foreach ($groups as $group) {
-            $group_result = [];
-            // TODO: Return proper objects instead of associative arrays.
-            $group_result['group_id'] = $group->id;
-            $group_result['group_name'] = $group->name;
-            $group_result['score'] = $this->score($group->id);
-            $result[] = $group_result;
-        }
-        return $result;
-    }
+	}
+
+	/**
+	 * Calculates total score for a single team.
+	 */
+	public function score_per_question( $group_id, $consider_overrides = true ) {
+		$points_overrides = array();
+		if ( $consider_overrides ) {
+			$points           = $this->points_dao->get_by_group( $group_id );
+			$points_overrides = array_combine( array_map( function ( $points ) {
+				return $points->form_question_id;
+			}, $points ), $points );
+		}
+
+		$scores    = [];
+		$responses = $this->response_dao->get_latest_by_group( $group_id );
+
+		foreach ( $this->questions as $question ) {
+			if ( isset( $responses[ $question->id ] ) ) {
+				$answers = $responses[ $question->id ]->answers;
+				// TODO: How should the is_reviewed flag be used? Only count points for answers where is_reviewed = true?
+				if ( isset( $answers ) ) {
+					$scores[ $question->id ] = $question->score( $answers );
+				}
+			}
+			if ( $consider_overrides
+			     && isset( $points_overrides[ $question->id ] )
+			     && isset( $responses[ $question->id ] )
+			     && $points_overrides[ $question->id ]->created > $responses[ $question->id ]->created ) {
+				$scores[ $question->id ] = $points_overrides[ $question->id ]->points;
+			}
+		}
+
+		return $scores;
+	}
+
+	public function score_board() {
+		$result = [];
+		$groups = $this->group_dao->get_all_in_competition( $this->competition_id );
+		foreach ( $groups as $group ) {
+			$group_result = [];
+			// TODO: Return proper objects instead of associative arrays.
+			$group_result['group_id']   = $group->id;
+			$group_result['group_name'] = $group->name;
+			$group_result['score']      = $this->score( $group->id, true );
+			$result[]                   = $group_result;
+		}
+
+		return $result;
+	}
 }

--- a/src/util/score/ScoreResult.php
+++ b/src/util/score/ScoreResult.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace tuja\util\score;
+
+
+class ScoreResult {
+	public $total_final = 0;
+	public $total_without_question_group_max_limits = 0;
+	public $questions = [];
+}
+
+class ScoreQuestionResult {
+	public $final = 0;
+	public $auto = 0;
+	public $override = 0;
+}

--- a/src/view/FieldImages.php
+++ b/src/view/FieldImages.php
@@ -23,24 +23,6 @@ class FieldImages extends Field
 		return array($answer);
 	}
 
-	// TODO: Move to AdminUtils.
-	public function render_admin_preview( $answer, $group_key = null ) {
-		$answer = json_decode($answer, true);
-		if (empty($answer['images'])) {
-			return '';
-		}
-
-		$image_manager = new ImageManager();
-
-		return join( array_map( function ( $image_id ) use ( $image_manager, $group_key ) {
-			$resized_image_url = $image_manager->get_resized_image_url( $image_id, 200 * 200, $group_key );
-
-			// TODO: Show fullsize image in modal popup when clicking image (see https://codex.wordpress.org/ThickBox)
-			return $resized_image_url ? sprintf( '<img src="%s">', $resized_image_url ) : 'Kan inte visa bild.';
-		}, $answer['images'] ) );
-	}
-
-
 	public function render($field_name) {
 		$hint = isset($this->hint) ? sprintf('<small class="tuja-question-hint">%s</small>', $this->hint) : '';
 
@@ -52,7 +34,6 @@ class FieldImages extends Field
 			$this->render_image_upload($field_name)
 		);
 	}
-
 
 	private function render_comment_field($field_name, $comment) {
 		ob_start();

--- a/src/view/FieldImages.php
+++ b/src/view/FieldImages.php
@@ -3,8 +3,6 @@
 namespace tuja\view;
 
 
-use tuja\util\ImageManager;
-
 class FieldImages extends Field
 {
 	const SHORT_LIST_LIMIT = 5;


### PR DESCRIPTION
Stöd för att begränsa mängden poäng för en frågegrupp. Begränsningen appliceras när ett lags totala poäng summeras.

* Inställningen sparas i en ny generell config-kolumn i databasen.
* Beräknas poäng för ett lag returneras som ett objekt från `score` istället för enskilda värden från flera olika metoder.