### PR TITLE
Prevent replacing score when reviewing answers #66

### DIFF
--- a/src/admin/views/review.php
+++ b/src/admin/views/review.php
@@ -7,17 +7,34 @@ AdminUtils::printTopMenu( $competition );
 ?>
 
 <form method="post" action="<?= add_query_arg() ?>">
-    <?php
+    <p>
+        Svar att visa:
+		<?php
+		foreach ( $question_filters as $question_filter ) {
+			if ( $question_filter['selected'] == true ) {
+				printf( ' <strong>%s</strong>', $question_filter['label'] );
+			} else {
+				printf( ' <a href="%s">%s</a>',
+					add_query_arg( array(
+						Review::QUESTION_FILTER_URL_PARAM => $question_filter['key'],
+					) ),
+					$question_filter['label'] );
+			}
+		}
+		?>
+    </p>
+
+	<?php
     if (empty($responses)) {
         printf('<p>Allt är redan kontrollerat. Bra jobbat!</p>');
     } else {
         ?>
 
-        <p>Här ser du vilka svar som ännu inte kontrollerats manuellt.</p>
         <p>
             Du ser vilken poäng som kommer delas ut om du inte gör något. Om du fyller i poäng för ett svar är det din
             poäng som räknas.
         </p>
+
         <table class="tuja-admin-review">
             <tbody>
             <tr>
@@ -44,7 +61,7 @@ AdminUtils::printTopMenu( $competition );
                                 $is_form_name_printed = true;
                             }
                             if (!$is_question_printed) {
-	                            printf( '<tr class="tuja-admin-review-question-row"><td></td><td colspan="5"><strong>%s</strong></td></tr>', $question->text );
+	                            printf( '<tr class="tuja-admin-review-question-row"><td></td><td colspan="5"><strong>%s</strong, > %s, %s</td></tr>', $question->text, $question->type, $question->score_type );
 	                            printf( '' .
 	                                    '<tr class="tuja-admin-review-correctanswer-row">' .
 	                                    '  <td colspan="2"></td>' .
@@ -89,7 +106,7 @@ AdminUtils::printTopMenu( $competition );
                                 is_array($response->answers) ? join('<br>', $response->answers) : '<em>Ogiltigt svar</em>',
 		                        $score_class,
 		                        $score,
-                                sprintf('tuja_review_points__%s__%s', $response->form_question_id, $response->group_id),
+		                        sprintf( 'tuja_review_points__%s', $response->id ),
 		                        $field_value,
 		                        $question->score_max ?: 1000 );
                         }


### PR DESCRIPTION
Två saker i denna:
* Enkel filtrering så att man kan välja mellan att visa alla svar eller bara bildsvar när man går igenom orättade svar. Detta är praktiskt för funk som bara ska rätta bilder (och därmed inte är intresserad av att kolla även svar som auto-rättningen ska ta hand om).
* Spara inte rättarens poäng om någon annan redan rättat frågan (ignorera senaste rättarens bedömning om någon annan rättare hann före).