### PR TITLE
Crew should be able to answer forms #86

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Features:
 Attributes:
 * form: The integer id (i.e. primary key in the database) for the form to display.
 * readonly: Boolean flag for whether or not user should be able to provide answers or if only current answer for each question is displayed. 
+* crew_override: Boolean flag for whether or not crew members answer for themselves (if omitted or `no`) or on behalf of another team (if `yes`). 
 
 Known issues:
 * 

--- a/src/inc/frontend.php
+++ b/src/inc/frontend.php
@@ -46,12 +46,13 @@ class Frontend extends Plugin {
 
 	public function form_shortcode( $atts ) {
 		global $wp_query, $wpdb;
-		$form_id     = $atts['form'];
-		$is_readonly = isset($atts['readonly']) && in_array( strtolower( $atts['readonly'] ), [ 'yes', 'true' ] );
-		$group_id    = $wp_query->query_vars['group_id'];
-		$component   = $is_readonly ?
+		$form_id          = $atts['form'];
+		$is_readonly      = self::bool_attr( $atts, 'readonly' );
+		$is_crew_override = self::bool_attr( $atts, 'crew_override' );
+		$group_id         = $wp_query->query_vars['group_id'];
+		$component        = $is_readonly ?
 			new FormReadonlyShortcode( $wpdb, $form_id, $group_id ) :
-			new FormShortcode( $wpdb, $form_id, $group_id );
+			new FormShortcode( $wpdb, $form_id, $group_id, $is_crew_override );
 
 		return $component->render();
 	}
@@ -76,7 +77,7 @@ class Frontend extends Plugin {
 	public function edit_group_shortcode( $atts ) {
 		global $wp_query, $wpdb;
 		$group_id                        = $wp_query->query_vars['group_id'];
-		$is_crew_form                    = $atts['is_crew_form'] === 'yes';
+		$is_crew_form                    = self::bool_attr( $atts, 'is_crew_form' );
 		$enable_group_category_selection = $atts['enable_group_category_selection'] !== 'no'; // Enabled if omitted, disable with 'no'.
 
 		$component = new EditGroupShortcode(
@@ -92,7 +93,7 @@ class Frontend extends Plugin {
 		global $wpdb;
 		$competition_id                  = $atts['competition'];
 		$edit_link_template              = $atts['edit_link_template'];
-		$is_crew_form                    = $atts['is_crew_form'] === 'yes';
+		$is_crew_form                    = self::bool_attr( $atts, 'is_crew_form' );
 		$enable_group_category_selection = $atts['enable_group_category_selection'] !== 'no'; // Enabled if omitted, disable with 'no'.
 
 		$component = new CreateGroupShortcode(
@@ -136,6 +137,13 @@ class Frontend extends Plugin {
 
 	public function form_closes_countdown_shortcode( $atts ) {
 		return CountdownShortcode::submit_form_response_closes( $atts );
+	}
+
+	private static function bool_attr( $attributes, $attr_name ): bool {
+		return isset( $attributes[ $attr_name ] ) && in_array( strtolower( $attributes[ $attr_name ] ), [
+				'yes',
+				'true'
+			] );
 	}
 }
 

--- a/src/view/FormShortcode.php
+++ b/src/view/FormShortcode.php
@@ -19,21 +19,24 @@ class FormShortcode extends AbstractShortcode
 	private $group_dao;
 	private $response_dao;
 	private $category_dao;
+	private $is_crew_override;
 
 	const RESPONSE_FIELD_NAME_PREFIX = 'tuja_formshortcode__response__';
 	const ACTION_FIELD_NAME = 'tuja_formshortcode__action';
 	const OPTIMISTIC_LOCK_FIELD_NAME = 'tuja_formshortcode__optimistic_lock';
 	const TEAMS_DROPDOWN_NAME = 'tuja_formshortcode__group';
 
-	public function __construct( $wpdb, $form_id, $group_key ) {
-		$this->form_id      = $form_id;
-		$this->group_key    = $group_key;
-		$this->question_dao = new QuestionDao();
+	public function __construct( $wpdb, $form_id, $group_key, $is_crew_override ) {
+		parent::__construct();
+		$this->form_id            = $form_id;
+		$this->group_key          = $group_key;
+		$this->is_crew_override   = $is_crew_override;
+		$this->question_dao       = new QuestionDao();
 		$this->question_group_dao = new QuestionGroupDao();
-		$this->group_dao    = new GroupDao();
-		$this->response_dao = new ResponseDao();
-		$this->form_dao     = new FormDao();
-		$this->category_dao = new GroupCategoryDao();
+		$this->group_dao          = new GroupDao();
+		$this->response_dao       = new ResponseDao();
+		$this->form_dao           = new FormDao();
+		$this->category_dao       = new GroupCategoryDao();
 	}
 
 	/**
@@ -125,8 +128,10 @@ class FormShortcode extends AbstractShortcode
 			return sprintf( '<p class="tuja-message tuja-message-error">%s</p>', 'Oj, vi vet inte vilket lag du tillhör.' );
 		}
 
-	    $group_category = $this->get_group_category( $group );
-	    if ( isset( $group_category ) && $group_category->is_crew ) {
+		$group_category              = $this->get_group_category( $group );
+		$crew_user_must_select_group = $this->is_crew_override;
+		$user_is_crew                = isset( $group_category ) && $group_category->is_crew;
+		if ( $user_is_crew && $crew_user_must_select_group ) {
             $participant_groups = $this->get_participant_groups();
 
 			$html_sections[] = sprintf( '<p>%s</p>', $this->get_groups_dropdown( $participant_groups ) );


### PR DESCRIPTION
Ny flagga till `[tuja_form]` för att inaktivera funktionen att funktionärer alltid måste svara å ett annat lags vägnar. Med denna flagga så kan ska svara som sig själva, vilket är precis vad vi behöver för att även funk ska kunna tävla med Häftet.