### PR TITLE
Issue 74 image upload

### DIFF
--- a/src/admin/AdminUtils.php
+++ b/src/admin/AdminUtils.php
@@ -69,7 +69,10 @@ class AdminUtils
 		$image_manager = new ImageManager();
 
 		return join( array_map( function ( $image_id ) use ( $image_manager, $group_key ) {
-			$resized_image_url = $image_manager->get_resized_image_url( $image_id, 200 * 200, $group_key );
+			$resized_image_url = $image_manager->get_resized_image_url(
+				$image_id,
+				ImageManager::DEFAULT_THUMBNAIL_PIXEL_COUNT,
+				$group_key );
 
 			// TODO: Show fullsize image in modal popup when clicking image (see https://codex.wordpress.org/ThickBox)
 			return $resized_image_url ? sprintf( '<img src="%s">', $resized_image_url ) : 'Kan inte visa bild.';

--- a/src/assets/css/wp.css
+++ b/src/assets/css/wp.css
@@ -163,6 +163,14 @@ p.tuja-message:last-child /* <--- Overrides other styling from tunnelbanejakten.
 	border-radius: 0;
 }
 
+.tuja-image .dropzone .dz-preview .dz-image img {
+    /* Height and width matches default Dropzone values. */
+    height: 120px;
+    width: 120px;
+    object-fit: contain;
+    object-position: center center;
+}
+
 .tuja-image .dropzone .dz-preview:hover .dz-image img {
 	-webkit-transform: none;
     -moz-transform: none;

--- a/src/assets/js/upload.js
+++ b/src/assets/js/upload.js
@@ -17,6 +17,7 @@
 				resizeWidth: 1000,
 				acceptedFiles: 'image/*',
 				parallelUploads: 2,
+				thumbnailMethod: 'contain',
 				maxFiles: maxFilesCount,
 				uploadMultiple: false,
 				dictDefaultMessage: 'Klicka här för att ladda upp bilder',

--- a/src/util/ImageManager.php
+++ b/src/util/ImageManager.php
@@ -8,6 +8,8 @@ use tuja\data\store\ResponseDao;
 
 class ImageManager
 {
+	const DEFAULT_THUMBNAIL_PIXEL_COUNT = 200 * 200;
+
     public function __construct()
     {
         $dir = wp_upload_dir('tuja', true, false);

--- a/src/view/FieldChoices.php
+++ b/src/view/FieldChoices.php
@@ -2,6 +2,8 @@
 
 namespace tuja\view;
 
+use tuja\data\model\Group;
+
 class FieldChoices extends Field
 {
     public $options;
@@ -28,7 +30,7 @@ class FieldChoices extends Field
         return $user_answer;
     }
 
-    public function render($field_name)
+    public function render($field_name, Group $group )
     {
         $render_id = $field_name ?: uniqid();
         $hint = isset($this->hint) ? sprintf('<small class="tuja-question-hint">%s</small>', $this->hint) : '';

--- a/src/view/FieldImages.php
+++ b/src/view/FieldImages.php
@@ -3,14 +3,23 @@
 namespace tuja\view;
 
 
+use tuja\data\model\Group;
+use tuja\util\ImageManager;
+
 class FieldImages extends Field
 {
 	const SHORT_LIST_LIMIT = 5;
+	private $image_manager;
 
-	public function get_posted_answer($form_field) {
+	public function __construct() {
+		parent::__construct();
+		$this->image_manager = new ImageManager();
+	}
+
+	public function get_posted_answer( $form_field ) {
 		$answer = array();
 		if (isset($_POST[$form_field])) {
-			$data   = sanitize_post($_POST[$form_field]);
+			$data   = sanitize_post( $_POST[ $form_field ] );
 			$answer = array(
 				'images'  => $data['images'],
 				'comment' => $data['comment']
@@ -21,7 +30,7 @@ class FieldImages extends Field
 		return array($answer);
 	}
 
-	public function render($field_name) {
+	public function render( $field_name, Group $group ) {
 		$hint = isset($this->hint) ? sprintf('<small class="tuja-question-hint">%s</small>', $this->hint) : '';
 
 		return sprintf(
@@ -29,15 +38,15 @@ class FieldImages extends Field
 			strtolower((new \ReflectionClass($this))->getShortName()),
 			$this->label,
 			$hint,
-			$this->render_image_upload($field_name)
+			$this->render_image_upload( $field_name, $group->random_id )
 		);
 	}
 
-	private function render_comment_field($field_name, $comment) {
+
+	private function render_comment_field( $field_name, $comment ) {
 		ob_start();
-		echo '<label for="' . $field_name . '-comment' . '">Kommentar</label>';
 		printf(
-			'<textarea rows="3" id="%s" name="%s[comment]" %s>%s</textarea>',
+			'<textarea rows="3" id="%s" name="%s[comment]" placeholder="Skriv kommentar här..." %s>%s</textarea>',
 			$field_name . '-comment',
 			$field_name,
 			$this->read_only ? ' disabled="disabled"' : '',
@@ -47,7 +56,7 @@ class FieldImages extends Field
 		return ob_get_clean();
 	}
 
-	private function render_image_upload($field_name) {
+	private function render_image_upload( $field_name, $group_key ) {
 		wp_enqueue_script('tuja-dropzone');
 		wp_enqueue_script('tuja-upload-script');
 
@@ -56,7 +65,15 @@ class FieldImages extends Field
 			$answer = json_decode($this->value[0], true);
 			if (!empty($answer['images'])) {
 				foreach ($answer['images'] as $filename) {
-					$images[] = sprintf('<input type="hidden" name="%s[images][]" value="%s">', $field_name, $filename);
+
+					$resized_image_url = $this->image_manager->get_resized_image_url(
+						$filename,
+						ImageManager::DEFAULT_THUMBNAIL_PIXEL_COUNT,
+						$group_key );
+
+					$images[] = sprintf( '<input type="hidden" name="%s[images][]" value="%s">',
+						$field_name,
+						$resized_image_url ? basename( $resized_image_url ) : $filename );
 				}
 			}
 		}

--- a/src/view/FieldPno.php
+++ b/src/view/FieldPno.php
@@ -3,6 +3,7 @@
 namespace tuja\view;
 
 use ReflectionClass;
+use tuja\data\model\Group;
 
 class FieldPno extends Field
 {
@@ -11,7 +12,7 @@ class FieldPno extends Field
         parent::__construct();
     }
 
-    public function render($field_name)
+    public function render($field_name, Group $group )
     {
         $render_id = $field_name ?: uniqid();
         $hint = isset($this->hint) ? sprintf('<small class="tuja-question-hint">%s</small>', $this->hint) : '';

--- a/src/view/FieldText.php
+++ b/src/view/FieldText.php
@@ -2,6 +2,8 @@
 
 namespace tuja\view;
 
+use tuja\data\model\Group;
+
 class FieldText extends Field
 {
 	private $html_props;
@@ -12,7 +14,7 @@ class FieldText extends Field
 	    $this->html_props = $html_props;
     }
 
-    public function render($field_name)
+    public function render($field_name, Group $group )
     {
         $render_id = $field_name ?: uniqid();
         $hint = isset($this->hint) ? sprintf('<small class="tuja-question-hint">%s</small>', $this->hint) : '';

--- a/src/view/FieldTextMulti.php
+++ b/src/view/FieldTextMulti.php
@@ -2,6 +2,8 @@
 
 namespace tuja\view;
 
+use tuja\data\model\Group;
+
 class FieldTextMulti extends Field {
 	public $options;
 
@@ -25,7 +27,7 @@ class FieldTextMulti extends Field {
 		}
 	}
 
-	public function render( $field_name ) {
+	public function render( $field_name, Group $group ) {
 		$render_id = $field_name ?: uniqid();
 		$hint      = isset( $this->hint ) ? sprintf( '<small class="tuja-question-hint">%s</small>', $this->hint ) : '';
 

--- a/src/view/FormShortcode.php
+++ b/src/view/FormShortcode.php
@@ -138,12 +138,11 @@ class FormShortcode extends AbstractShortcode
 
 			$selected_participant_group = $this->get_selected_group( $participant_groups );
 
-			$target_group_id = $selected_participant_group->id;
 		    $target_group = $selected_participant_group;
 		} else {
 			$target_group = $group;
-			$target_group_id = $group->id;
 		}
+		$target_group_id = $group->id;
 
 		$is_read_only = ! $this->is_submit_allowed();
 

--- a/src/view/FormShortcode.php
+++ b/src/view/FormShortcode.php
@@ -133,21 +133,23 @@ class FormShortcode extends AbstractShortcode
 
 			$selected_participant_group = $this->get_selected_group( $participant_groups );
 
-			$group_id = $selected_participant_group->id;
+			$target_group_id = $selected_participant_group->id;
+		    $target_group = $selected_participant_group;
 		} else {
-			$group_id = $group->id;
+			$target_group = $group;
+			$target_group_id = $group->id;
 		}
 
 		$is_read_only = ! $this->is_submit_allowed();
 
-		if ( $group_id ) {
+		if ( $target_group_id ) {
 			$message_success = null;
 			$message_error   = null;
 			$errors          = array();
 			$is_update = isset($_POST[ self::ACTION_FIELD_NAME ]) && $_POST[ self::ACTION_FIELD_NAME ] === 'update';
 
 			if ($is_update) {
-				$errors = $this->update_answers( $group_id );
+				$errors = $this->update_answers( $target_group_id );
 				if ( empty( $errors ) ) {
 					$message_success = 'Era svar har sparats.';
 					$html_sections[] = sprintf( '<p class="tuja-message tuja-message-success">%s</p>', $message_success );
@@ -160,7 +162,7 @@ class FormShortcode extends AbstractShortcode
 				}
 			}
 
-			$responses = $this->response_dao->get_latest_by_group( $group_id );
+			$responses = $this->response_dao->get_latest_by_group( $target_group_id );
 			$question_groups = $this->question_group_dao->get_all_in_form( $this->form_id );
 			
 			foreach($question_groups as $question_group) {
@@ -183,7 +185,7 @@ class FormShortcode extends AbstractShortcode
 					}
 					$field            = Field::create( $question );
 					$field->read_only = $is_read_only;
-					$html_field       = $field->render( $field_name );
+					$html_field       = $field->render( $field_name, $target_group );
 					
 					$current_group .= sprintf( '<div class="tuja-question %s" data-id="%d">%s%s</div>',
 						isset( $errors[ $field_name ] ) ? 'tuja-field-error' : '',
@@ -202,7 +204,7 @@ class FormShortcode extends AbstractShortcode
 				$question_ids = array_map( function ( $question ) {
 					return $question->id;
 				}, $questions );
-				$optimistic_lock_value = $this->get_optimistic_lock_value($group_id, (array)$question_ids);
+				$optimistic_lock_value = $this->get_optimistic_lock_value($target_group_id, (array)$question_ids);
 
 				$html_sections[] = sprintf( '<input type="hidden" name="%s" value="%s">', self::OPTIMISTIC_LOCK_FIELD_NAME, $optimistic_lock_value );
 				$html_sections[] = sprintf( '<input type="hidden" name="%s" value="%s">', 'group', $group_key );


### PR DESCRIPTION
Två detaljer som fixas till med denna PR:
* Thumbnails för redan uppladdade bilder genereras av servern, och därmed behöver mindre mängd data hämtas av webbläsaren (`FieldImages.php`, och lite justeringar i övriga `Field*.php` för att vara konsekvent).
* Thumbnails skalas lite annorlunda så att hela bilden alltid visas, istället för inzoomat/beskuret, och därmed vet de tävlande att allt i bilden syns (`wp.css` och `upload.js`).