### PR TITLE
Hide header in registration evaluation report #90

### DIFF
--- a/src/util/Template.php
+++ b/src/util/Template.php
@@ -58,25 +58,31 @@ class Template
 	    $registration_evaluator = new RegistrationEvaluator();
 	    $evaluation_result      = $registration_evaluator->evaluate( $group );
         return [
-	        'group_name' => $group->name,
-	        'group_key'  => $group->random_id,
-	        'group_registration_evaluation_warnings' => self::group_parameter_registration_issues( 'Sådant som ni borde fixa:', $evaluation_result, RuleResult::WARNING ),
-	        'group_registration_evaluation_errors'   => self::group_parameter_registration_issues( 'Sådant som ni måste fixa för att få starta:', $evaluation_result, RuleResult::BLOCKER )
+	        'group_name'                             => $group->name,
+	        'group_key'                              => $group->random_id,
+	        'group_registration_evaluation_warnings' => self::group_parameter_registration_issues( 'Sådant som ni **borde** fixa:', $evaluation_result, RuleResult::WARNING ),
+	        'group_registration_evaluation_errors'   => self::group_parameter_registration_issues( 'Sådant som ni **måste** fixa för att få starta:', $evaluation_result, RuleResult::BLOCKER )
         ];
     }
 
 	private static function group_parameter_registration_issues( $header, array $evaluation_result, $status ) {
+		$issues = array_filter(
+			$evaluation_result,
+			function ( $issue ) use ( $status ) {
+				return $issue->status === $status;
+			} );
+
+		if ( empty( $issues ) ) {
+			return '';
+		}
+
 		return $header . "\n" . join(
 				"\n",
 				array_map(
 					function ( $issue ) {
 						return sprintf( '- %s. %s', $issue->rule_name, $issue->details );
 					},
-					array_filter(
-						$evaluation_result,
-						function ( $issue ) use ( $status ) {
-							return $issue->status === $status;
-						} ) ) );
+					$issues ) );
 	}
 
 	public static function site_parameters()


### PR DESCRIPTION
Skulle vara trevligt att slippa onödiga rubriker om det bara finns antingen fel eller varningar i listan över problem med anmälningarna.

Exempel när det finns två rubriker men bara en hade varit bättre:
![image](https://user-images.githubusercontent.com/789455/56498559-88bdf080-6502-11e9-8e97-e91072b37829.png)
