### PR TITLE
Group admin cannot add team leader

### DIFF
--- a/src/frontend/GroupPeopleEditor.php
+++ b/src/frontend/GroupPeopleEditor.php
@@ -89,9 +89,15 @@ class GroupPeopleEditor extends AbstractGroupView {
 					return $person->get_type() === $type;
 				} );
 
+				$are_more_people_allowed = true; // count($people) < $max;
+				$are_fewer_people_allowed = true; // count($people) > $min;
+
 				$form = $this->get_form_people_html( $people,
 					$errors,
-					$min == $max,
+					// Enable button to add more people if we haven't reached the upper limit yet
+					$are_more_people_allowed,
+					// Enable button to remove people only there is already enough people added
+					$are_fewer_people_allowed,
 					$type,
 					Strings::get( 'group_people_editor.' . $type . '.add_button' ) );
 
@@ -122,7 +128,8 @@ class GroupPeopleEditor extends AbstractGroupView {
 	private function get_form_people_html(
 		array $people,
 		array $errors,
-		bool $is_fixed_list,
+		bool $is_add_enabled,
+		bool $is_remove_enabled,
 		string $role,
 		string $add_button_label = 'Ny person'
 	) {
@@ -130,16 +137,16 @@ class GroupPeopleEditor extends AbstractGroupView {
 
 		if ( is_array( $people ) ) {
 			$html_sections[] = sprintf( '<div class="tuja-people-existing">%s</div>',
-				join( array_map( function ( Person $person ) use ( $errors, $is_fixed_list ) {
-					return $this->render_person_form( $person, ! $is_fixed_list );
+				join( array_map( function ( Person $person ) use ( $errors, $is_remove_enabled ) {
+					return $this->render_person_form( $person, $is_remove_enabled );
 				}, $people ) ) );
 		}
 
-		if ( ! $is_fixed_list ) {
+		if ( $is_add_enabled ) {
 			$html_sections[] = sprintf( '<div class="tuja-item-buttons"><button type="button" value="%s" class="tuja-add-person">%s</button></div>', 'new_person', $add_button_label );
 			$person_template = new Person();
 			$person_template->set_type( $role );
-			$html_sections[] = sprintf( '<div class="tuja-person-template">%s</div>', $this->render_person_form( $person_template, ! $is_fixed_list ) );
+			$html_sections[] = sprintf( '<div class="tuja-person-template">%s</div>', $this->render_person_form( $person_template, $is_remove_enabled ) );
 		}
 
 		return sprintf( '<div class="tuja-people tuja-person-role-%s">%s</div>', $role, join( $html_sections ) );

--- a/tests/integration/index.team-management.test.js
+++ b/tests/integration/index.team-management.test.js
@@ -16,6 +16,7 @@ const expectErrorMessage = async (expected) => defaultPage.expectErrorMessage(ex
 const expectFormValue = async (selector, expected) => defaultPage.expectFormValue(selector, expected)
 const expectPageTitle = async (expected) => defaultPage.expectPageTitle(expected)
 const expectElementCount = async (selector, expectedCount) => defaultPage.expectElementCount(selector, expectedCount)
+const takeScreenshot = async () => defaultPage.takeScreenshot()
 
 jest.setTimeout(300000)
 
@@ -393,7 +394,7 @@ describe('Team Management', () => {
         await verifyFeePage.close()
       })
 
-      it('should be possible to sign up as administrator', async () => {
+      it('should be possible to sign up as administrator and later add team leader', async () => {
         const tempGroupProps = await defaultPage.signUpTeam(adminPage, true, false)
 
         await goto(`http://localhost:8080/${tempGroupProps.key}/andra-personer`)
@@ -403,6 +404,18 @@ describe('Team Management', () => {
         await expectElementCount('div.tuja-person-role-supervisor > div.tuja-people-existing > div.tuja-signup-person', 0)
         await expectElementCount('div.tuja-person-role-admin > div.tuja-people-existing > div.tuja-signup-person', 1)
         await expectFormValue('div.tuja-person-role-admin > div.tuja-people-existing > div.tuja-signup-person input[name^="tuja-person__email__"]', 'amber@example.com')
+
+        const addLeaderTeamMember = async (name, birthDate, phone, email) => {
+          await click('div.tuja-person-role-leader button.tuja-add-person')
+          await type('div.tuja-person-role-leader div.tuja-signup-person:last-child input[name^="tuja-person__name__"]', name)
+          await type('div.tuja-person-role-leader div.tuja-signup-person:last-child input[name^="tuja-person__pno__"]', birthDate)
+          await type('div.tuja-person-role-leader div.tuja-signup-person:last-child input[name^="tuja-person__phone__"]', phone)
+          await type('div.tuja-person-role-leader div.tuja-signup-person:last-child input[name^="tuja-person__email__"]', email)
+        }
+        await addLeaderTeamMember('Bob', '20001010-1234', '+4670123456', 'bob@example.com')
+
+        await clickLink('button[name="tuja-action"]')
+        await expectSuccessMessage('Ändringarna har sparats.')
       })
 
       it('should be possible to edit team members', async () => {


### PR DESCRIPTION
Om man anmäler ett lag åt någon annan, dvs. man är admin för laget men inte lagledare, så kan man inte lägga till en lagledare heller eftersom knappen är dold.

Denna PR löser problemet genom att alltid visa alla knappar för att lägga till eller ta bort deltagare, även om det betyder att det är möjligt att lägga till för många. Hellre för många registrerade lagledare än inga alls.