### PR TITLE
Allow Markdown in question texts

### DIFF
--- a/src/api/Questions.php
+++ b/src/api/Questions.php
@@ -17,6 +17,7 @@ use tuja\data\store\QuestionDao;
 use tuja\data\store\QuestionGroupDao;
 use tuja\data\store\ResponseDao;
 use tuja\frontend\Form;
+use tuja\util\Template;
 use tuja\util\JwtUtils;
 use tuja\util\ReflectionUtils;
 use tuja\frontend\FormUserChanges;
@@ -137,6 +138,11 @@ class Questions extends AbstractRestEndpoint {
 			}
 		} else {
 			$response['config'] = $question->get_public_properties();
+		}
+
+		if ( isset( $response['config']['text'] ) ) {
+			// Parse Markdown texts into HTML.
+			$response['config']['text'] = Template::string( $response['config']['text'] )->render( array(), true );
 		}
 
 		return $response;

--- a/src/data/model/question/ImagesQuestion.schema.json
+++ b/src/data/model/question/ImagesQuestion.schema.json
@@ -4,7 +4,7 @@
     "text": {
       "title": "Fråga",
       "type": "string",
-      "format": "text"
+      "format": "textarea"
     },
     "text_hint": {
       "title": "Hjälptext",

--- a/src/data/model/question/NumberQuestion.schema.json
+++ b/src/data/model/question/NumberQuestion.schema.json
@@ -4,7 +4,7 @@
     "text": {
       "title": "Fråga",
       "type": "string",
-      "format": "text"
+      "format": "textarea"
     },
     "text_hint": {
       "title": "Hjälptext",

--- a/src/data/model/question/OptionsQuestion.schema.json
+++ b/src/data/model/question/OptionsQuestion.schema.json
@@ -4,7 +4,7 @@
     "text": {
       "title": "Fråga",
       "type": "string",
-      "format": "text"
+      "format": "textarea"
     },
     "text_hint": {
       "title": "Hjälptext",

--- a/src/data/model/question/TextQuestion.schema.json
+++ b/src/data/model/question/TextQuestion.schema.json
@@ -4,7 +4,7 @@
     "text": {
       "title": "Fråga",
       "type": "string",
-      "format": "text"
+      "format": "textarea"
     },
     "text_hint": {
       "title": "Hjälptext",

--- a/src/tuja.php
+++ b/src/tuja.php
@@ -410,6 +410,7 @@ abstract class Plugin {
 			self::PATH . '/data/model/question/' . $classname . '.php',
 			self::PATH . '/util/router/' . $classname . '.php',
 			self::PATH . '/util/markdown/' . $classname . '.php',
+			self::PATH . '/util/formattedtext/' . $classname . '.php',
 			self::PATH . '/util/messaging/' . $classname . '.php',
 			self::PATH . '/util/concurrency/' . $classname . '.php',
 			self::PATH . '/util/rules/' . $classname . '.php',

--- a/src/util/Template.php
+++ b/src/util/Template.php
@@ -13,7 +13,7 @@ use tuja\frontend\router\GroupSignupInitiator;
 use tuja\frontend\router\GroupStatusInitiator;
 use tuja\frontend\router\GroupTicketsInitiator;
 use tuja\frontend\router\PersonEditorInitiator;
-use tuja\util\markdown\Parsedown;
+use tuja\util\formattedtext\FormattedText;
 use tuja\data\model\Group;
 use tuja\data\model\Person;
 use tuja\util\rules\RuleResult;
@@ -31,7 +31,7 @@ class Template {
 			$rendered_content = str_replace( '{{' . $name . '}}', $value, $rendered_content );
 		}
 		if ( $is_markdown ) {
-			$markdown_parser = new Parsedown();
+			$markdown_parser = new FormattedText();
 
 			return $markdown_parser->parse( $rendered_content );
 		} else {

--- a/src/util/formattedtext/FormattedText.php
+++ b/src/util/formattedtext/FormattedText.php
@@ -1,0 +1,38 @@
+<?php
+namespace tuja\util\formattedtext;
+
+use tuja\util\markdown\Parsedown;
+
+/**
+ * Regular Markdown parser but image URLs are WordPress media file ids instead.
+ */
+class FormattedText extends Parsedown {
+
+	/**
+	 * This Markdown will be replaced by an <img> element displaying media file 1337 in large size:
+	 *   ![](1337)
+	 */
+	protected function inlineImage( $excerpt ) {
+		$image = parent::inlineImage( $excerpt );
+
+		if ( ! isset( $image ) ) {
+			return null;
+		}
+
+		// Reference: https://developer.wordpress.org/reference/functions/wp_get_attachment_image_src/.
+		$image_data = wp_get_attachment_image_src(
+			intval( $image['element']['attributes']['src'] ),
+			'large', // Any registered image size name, e.g. 'thumbnail'.
+			false
+		);
+
+		if ( $image_data === false ) {
+			return null;
+		}
+
+		list ($url, $width, $height, $is_resized) = $image_data;
+		$image['element']['attributes']['src']    = $url;
+
+		return $image;
+	}
+}

--- a/src/view/Field.php
+++ b/src/view/Field.php
@@ -2,6 +2,7 @@
 
 namespace tuja\view;
 
+use tuja\util\Template;
 use tuja\data\model\Group;
 
 abstract class Field {
@@ -10,7 +11,8 @@ abstract class Field {
 	protected $read_only;
 
 	public function __construct( $label, $hint = null, $read_only = false ) {
-		$this->label     = $label;
+		$formatted_label = Template::string( $label )->render( array(), true );
+		$this->label     = $formatted_label;
 		$this->hint      = $hint;
 		$this->read_only = $read_only;
 	}
@@ -21,7 +23,7 @@ abstract class Field {
 	 * Returns the data used to render the component.
 	 *
 	 * @param string $field_name The name of the field in $_POST
-	 * @param mixed $stored_posted_answer Data to be used if no data is found in $_POST
+	 * @param mixed  $stored_posted_answer Data to be used if no data is found in $_POST
 	 *
 	 * @return mixed
 	 */


### PR DESCRIPTION
Two things:
* allow Markdown in question texts and,
* extend Markdown with support for images from WP media library.